### PR TITLE
    Solving the problem that RIPE style WHOIS answers need to end with

### DIFF
--- a/irrd/server/whois/query_response.py
+++ b/irrd/server/whois/query_response.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from typing import Optional
 
@@ -74,12 +75,20 @@ class WhoisQueryResponse:
         return None
 
     def _generate_response_ripe(self) -> Optional[str]:
+        s = None
         if self.response_type == WhoisQueryResponseType.SUCCESS:
             if self.result:
-                return self.result + '\n\n'
-            return '%  No entries found for the selected source(s).\n'
+                s = self.result
+            else:
+                s = '%  No entries found for the selected source(s).'
         elif self.response_type == WhoisQueryResponseType.KEY_NOT_FOUND:
-            return '%  No entries found for the selected source(s).\n'
+            s = '%  No entries found for the selected source(s).'
         elif self.response_type == WhoisQueryResponseType.ERROR:
-            return f'%% ERROR: {self.result}\n'
+            s = f'%% ERROR: {self.result}'
+        if s is not None:
+            # Sending an RPSL response in RIPE format. According to
+            # https://www.ripe.net/manage-ips-and-asns/db/support/documentation/ripe-database-query-reference-manual#2-0-querying-the-ripe-database
+            # there need to be exactly 2 empty lines at the end of a response.
+            s = s.rstrip('\n')
+            return "{0}{1}\n\n".format(s, '\n' if len(s) else '')
         return None

--- a/irrd/server/whois/query_response.py
+++ b/irrd/server/whois/query_response.py
@@ -1,4 +1,3 @@
-import re
 from enum import Enum
 from typing import Optional
 

--- a/irrd/utils/text.py
+++ b/irrd/utils/text.py
@@ -42,7 +42,7 @@ def split_paragraphs_rpsl(input: Union[str, TextIO], strip_comments=True) -> Ite
     if isinstance(input, str):
         generator = splitline_unicodesafe(input)
     else:
-        generator = iter(input.readlines())
+        generator = iter(input)
 
     for line in generator:
         line = line.strip('\r\n')


### PR DESCRIPTION
    Solving the problem that RIPE style WHOIS answers need to end with
    exactly 2 empty lines. While not part of the RPSL RFCs and WHOIS
    per se, this became necessary by continued connection usage (-k).

   Fixes #335 

    The client need to detect the end of a RPSL response, irregardless
    of query and network timings. See also:
    <https://www.ripe.net/manage-ips-and-asns/db/support/documentation/ripe-database-query-reference-manual#2-0-querying-the-ripe-database>