### PR TITLE
Optimise multiprocess whois server processes

### DIFF
--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -192,8 +192,12 @@ Servers
   denied for HTTP.
   |br| **Change takes effect**: after SIGHUP.
 * ``server.whois.max_connections``: the maximum number of simultaneous whois
-  connections permitted.
-  |br| **Default**: ``50``.
+  connections permitted. Note that each permitted connection will result in
+  one IRRd whois worker to be started, each of which use about 200 MB memory.
+  For example, if you set this to 10, you need about 2 GB of memory just for
+  IRRd's whois server
+  (and additional memory for other components and PostgreSQL).
+  |br| **Default**: ``5``.
   |br| **Change takes effect**: after full IRRd restart.
 
 

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -194,7 +194,7 @@ Servers
 * ``server.whois.max_connections``: the maximum number of simultaneous whois
   connections permitted. Note that each permitted connection will result in
   one IRRd whois worker to be started, each of which use about 200 MB memory.
-  For example, if you set this to 10, you need about 2 GB of memory just for
+  For example, if you set this to 50, you need about 10 GB of memory just for
   IRRd's whois server
   (and additional memory for other components and PostgreSQL).
   |br| **Default**: ``10``.

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -194,8 +194,7 @@ Servers
 * ``server.whois.max_connections``: the maximum number of simultaneous whois
   connections permitted.
   |br| **Default**: ``50``.
-  |br| **Change takes effect**: after SIGHUP. Existing connections will not
-  be terminated.
+  |br| **Change takes effect**: after full IRRd restart.
 
 
 Email

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -197,7 +197,7 @@ Servers
   For example, if you set this to 10, you need about 2 GB of memory just for
   IRRd's whois server
   (and additional memory for other components and PostgreSQL).
-  |br| **Default**: ``5``.
+  |br| **Default**: ``10``.
   |br| **Change takes effect**: after full IRRd restart.
 
 

--- a/docs/admins/deployment.rst
+++ b/docs/admins/deployment.rst
@@ -58,7 +58,7 @@ A few PostgreSQL settings need to be changed from their default:
   memory to benefit from caching, with a max of a few GB.
 * ``max_connections`` may need to be increased from 100. Generally, there
   will be one open connection for:
-  * Each open whois connection
+  * Each whois connection
   * Each running mirror import and export process
   * Each RPKI update process
   * Each run of ``irrd_load_database``

--- a/docs/admins/deployment.rst
+++ b/docs/admins/deployment.rst
@@ -58,7 +58,7 @@ A few PostgreSQL settings need to be changed from their default:
   memory to benefit from caching, with a max of a few GB.
 * ``max_connections`` may need to be increased from 100. Generally, there
   will be one open connection for:
-  * Each whois connection
+  * Each permitted whois connection
   * Each running mirror import and export process
   * Each RPKI update process
   * Each run of ``irrd_load_database``

--- a/docs/releases/4.1.0.rst
+++ b/docs/releases/4.1.0.rst
@@ -65,9 +65,9 @@ for further details.
 Other changes
 ~~~~~~~~~~~~~
 * The default for ``server.whois.max_connections`` has been reduced from 50
-  to 5. In 4.1, IRRd whois workers use considerably more memory, about 200 MB
+  to 10. In 4.1, IRRd whois workers use considerably more memory, about 200 MB
   each, and one worker is started for each permitted connection. Therefore,
-  at the default 5 connections, the whois processes use about 1 GB of memory,
+  at the default 10 connections, the whois processes use about 2 GB of memory,
   at 50 connections, this is about 10 GB.
 * Serial handling in IRRd has changed. If you mirror a source over NRTM, and
   keep a local journal, IRRd used to keep these serials identical. The NRTM

--- a/docs/releases/4.1.0.rst
+++ b/docs/releases/4.1.0.rst
@@ -6,9 +6,9 @@ IRRd 4.1.0 adds :doc:`RPKI-aware mode </admins/rpki>`
 and a new daemon architecture with full multiprocessing,
 along with several other improvements.
 
+IRRd 4.1.0 contains several significant changes, so please
+read these release notes carefully.
 Upgrading to IRRd 4.1.0 requires several changes to the deployment setup.
-This page contains details on the changes compared to
-IRRd 4.0, and how to upgrade.
 
 .. contents:: :backlinks: none
 
@@ -64,6 +64,11 @@ for further details.
 
 Other changes
 ~~~~~~~~~~~~~
+* The default for ``server.whois.max_connections`` has been reduced from 50
+  to 5. In 4.1, IRRd whois workers use considerably more memory, about 200 MB
+  each, and one worker is started for each permitted connection. Therefore,
+  at the default 5 connections, the whois processes use about 1 GB of memory,
+  at 50 connections, this is about 10 GB.
 * Serial handling in IRRd has changed. If you mirror a source over NRTM, and
   keep a local journal, IRRd used to keep these serials identical. The NRTM
   ADD from the original source would be stored in the local journal under the

--- a/irrd/conf/default_config.yaml
+++ b/irrd/conf/default_config.yaml
@@ -39,7 +39,7 @@ irrd:
         whois:
             interface: '::0'
             port: 43
-            max_connections: 50
+            max_connections: 5
     auth:
         gnupg_keyring: null
     email:

--- a/irrd/conf/default_config.yaml
+++ b/irrd/conf/default_config.yaml
@@ -39,7 +39,7 @@ irrd:
         whois:
             interface: '::0'
             port: 43
-            max_connections: 5
+            max_connections: 10
     auth:
         gnupg_keyring: null
     email:

--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -115,7 +115,7 @@ def run_irrd(mirror_frequency: int):
         # This loops every second to prevent long blocking on SIGTERM.
         mirror_scheduler.update_process_state()
         if sleeps >= mirror_frequency:
-            # mirror_scheduler.run()
+            mirror_scheduler.run()
             sleeps = 0
         time.sleep(1)
         sleeps += 1

--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -115,7 +115,7 @@ def run_irrd(mirror_frequency: int):
         # This loops every second to prevent long blocking on SIGTERM.
         mirror_scheduler.update_process_state()
         if sleeps >= mirror_frequency:
-            mirror_scheduler.run()
+            # mirror_scheduler.run()
             sleeps = 0
         time.sleep(1)
         sleeps += 1

--- a/irrd/server/http/server.py
+++ b/irrd/server/http/server.py
@@ -37,7 +37,7 @@ def start_http_server():  # pragma: no cover
     httpd.serve_forever()
 
 
-class HTTPServerForkingIPv6(socketserver.ForkingMixIn, HTTPServer):  # pragma: no cover
+class HTTPServerForkingIPv6(socketserver.ThreadingMixIn, HTTPServer):  # pragma: no cover
     # Default HTTP server only supports IPv4
     allow_reuse_address = True
     timeout = HTTP_TIMEOUT

--- a/irrd/server/whois/query_parser.py
+++ b/irrd/server/whois/query_parser.py
@@ -44,7 +44,7 @@ class WhoisQueryParser:
     database_handler: DatabaseHandler
     _current_set_root_object_class: Optional[str]
 
-    def __init__(self, client_ip: str, client_str: str) -> None:
+    def __init__(self, client_ip: str, client_str: str, preloader: Preloader) -> None:
         self.all_valid_sources = list(get_setting('sources', {}).keys())
         self.sources_default = get_setting('sources_default')
         self.sources: List[str] = self.sources_default if self.sources_default else self.all_valid_sources
@@ -59,8 +59,7 @@ class WhoisQueryParser:
         self.key_fields_only = False
         self.client_ip = client_ip
         self.client_str = client_str
-        self.preloader = Preloader()
-        self._preloaded_query_count = 0
+        self.preloader = preloader
         self.database_handler = DatabaseHandler()
 
     def handle_query(self, query: str) -> WhoisQueryResponse:
@@ -210,7 +209,6 @@ class WhoisQueryParser:
         except ValidationError as ve:
             raise WhoisQueryParserException(str(ve))
 
-        self._preloaded_query_called()
         prefixes = self.preloader.routes_for_origins([origin_formatted], self.sources, ip_version=ip_version)
         return ' '.join(prefixes)
 
@@ -229,7 +227,6 @@ class WhoisQueryParser:
         if not set_name:
             raise WhoisQueryParserException('Missing required set name for A query')
 
-        self._preloaded_query_called()
         self._current_set_root_object_class = 'as-set'
         members = self._recursive_set_resolve({set_name})
         prefixes = self.preloader.routes_for_origins(members, self.sources, ip_version=ip_version)
@@ -240,7 +237,6 @@ class WhoisQueryParser:
         !i query - find all members of an as-set or route-set, possibly recursively.
         e.g. !iAS-FOO for non-recursive, !iAS-FOO,1 for recursive
         """
-        self._preloaded_query_called()
         recursive = False
         if parameter.endswith(',1'):
             recursive = True
@@ -710,13 +706,3 @@ class WhoisQueryParser:
                         result += f'{field_name}: {field_data}\n'
             results.add(result)
         return '\n'.join(results)
-
-    def _preloaded_query_called(self):
-        """
-        Called each time the user runs a query that can be preloaded.
-        After the 5th, load the preload store into memory to speed
-        up expected further queries.
-        """
-        self._preloaded_query_count += 1
-        if self._preloaded_query_count > 5:
-            self.preloader.load_routes_into_memory()

--- a/irrd/server/whois/query_parser.py
+++ b/irrd/server/whois/query_parser.py
@@ -61,6 +61,7 @@ class WhoisQueryParser:
         self.client_str = client_str
         self.preloader = Preloader()
         self._preloaded_query_count = 0
+        self.database_handler = DatabaseHandler()
 
     def handle_query(self, query: str) -> WhoisQueryResponse:
         """
@@ -68,7 +69,6 @@ class WhoisQueryParser:
         Not thread safe - only one call must be made to this method at the same time.
         """
         # These flags are reset with every query.
-        self.database_handler = DatabaseHandler()
         self.key_fields_only = False
         self.object_classes = []
 

--- a/irrd/server/whois/server.py
+++ b/irrd/server/whois/server.py
@@ -14,6 +14,7 @@ from irrd.conf import get_setting
 from irrd.server.access_check import is_client_permitted
 from irrd.server.whois.query_parser import WhoisQueryParser
 from irrd.storage.database_handler import DatabaseHandler
+from irrd.storage.preload import Preloader
 from irrd.utils.process_support import ExceptionLoggingProcess
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,7 @@ class WhoisWorker(mp.Process, socketserver.StreamRequestHandler):
         # (signal handlers are inherited)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
+        self.preloader = Preloader()
         while True:
             try:
                 setproctitle('irrd-whois-worker')
@@ -137,7 +139,7 @@ class WhoisWorker(mp.Process, socketserver.StreamRequestHandler):
             self.wfile.write(b'%% Access denied')
             return
 
-        self.query_parser = WhoisQueryParser(client_ip, self.client_str)
+        self.query_parser = WhoisQueryParser(client_ip, self.client_str, self.preloader)
 
         data = True
         elapsed = time.perf_counter() - start_time

--- a/irrd/server/whois/server.py
+++ b/irrd/server/whois/server.py
@@ -64,8 +64,7 @@ class WhoisTCPServer(socketserver.TCPServer):  # pragma: no cover
 
         self.connection_queue = mp.Queue()
         self.workers = []
-        # for i in range(int(get_setting('server.whois.max_connections'))):
-        for i in range(2):
+        for i in range(int(get_setting('server.whois.max_connections'))):
             worker = WhoisWorker(self.connection_queue)
             worker.start()
             self.workers.append(worker)

--- a/irrd/server/whois/server.py
+++ b/irrd/server/whois/server.py
@@ -1,21 +1,18 @@
-import time
-
 import logging
+import multiprocessing as mp
 import signal
 import socket
 import socketserver
 import threading
+import time
 
 from IPy import IP
 from setproctitle import setproctitle
 
-import multiprocessing as mp
 from irrd.conf import get_setting
 from irrd.server.access_check import is_client_permitted
 from irrd.server.whois.query_parser import WhoisQueryParser
-from irrd.storage.database_handler import DatabaseHandler
 from irrd.storage.preload import Preloader
-from irrd.utils.process_support import ExceptionLoggingProcess
 
 logger = logging.getLogger(__name__)
 mp.allow_connection_pickling()
@@ -117,7 +114,7 @@ class WhoisWorker(mp.Process, socketserver.StreamRequestHandler):
             except Exception as e:
                 try:
                     self.close_request()
-                except Exception:
+                except Exception:  # pragma: no cover
                     pass
                 logger.error(f'Failed to handle whois connection, traceback follows: {e}',
                              exc_info=e)

--- a/irrd/server/whois/server.py
+++ b/irrd/server/whois/server.py
@@ -131,7 +131,7 @@ class WhoisWorker(mp.Process, socketserver.StreamRequestHandler):
             # explicitly shutdown.  socket.close() merely releases
             # the socket and waits for GC to perform the actual close.
             self.request.shutdown(socket.SHUT_WR)
-        except OSError:
+        except OSError:  # pragma: no cover
             pass  # some platforms may raise ENOTCONN here
         self.request.close()
 

--- a/irrd/server/whois/server.py
+++ b/irrd/server/whois/server.py
@@ -103,7 +103,13 @@ class WhoisWorker(mp.Process, socketserver.StreamRequestHandler):
         # (signal handlers are inherited)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
 
-        self.preloader = Preloader()  # TODO: wrap exceptions
+        try:
+            self.preloader = Preloader()
+        except Exception as e:
+            logger.error(f'Whois worker failed to initialise preloader, unable to start, '
+                         f'traceback follows: {e}', exc_info=e)
+            return
+
         while True:
             try:
                 setproctitle('irrd-whois-worker')

--- a/irrd/server/whois/tests/test_query_parser.py
+++ b/irrd/server/whois/tests/test_query_parser.py
@@ -62,9 +62,8 @@ def prepare_parser(monkeypatch, config_override):
     mock_database_query = Mock()
     monkeypatch.setattr('irrd.server.whois.query_parser.RPSLDatabaseQuery', lambda columns=None, ordered_by_sources=True: mock_database_query)
     mock_preloader = Mock(spec=Preloader)
-    monkeypatch.setattr('irrd.server.whois.query_parser.Preloader', lambda: mock_preloader)
 
-    parser = WhoisQueryParser('127.0.0.1', '127.0.0.1:99999')
+    parser = WhoisQueryParser('127.0.0.1', '127.0.0.1:99999', mock_preloader)
 
     mock_query_result = [
         {
@@ -514,16 +513,6 @@ class TestWhoisQueryParserIRRD:
         assert response.response_type == WhoisQueryResponseType.KEY_NOT_FOUND
         assert response.mode == WhoisQueryResponseMode.IRRD
         assert not response.result
-
-        # Test eventual pre-preloading with multiple qualifying queries
-        assert not mock_preloader.load_routes_into_memory.mock_calls
-        parser.handle_query('!gAS65547')
-        parser.handle_query('!gAS65547')
-        parser.handle_query('!gAS65547')
-        parser.handle_query('!gAS65547')
-        parser.handle_query('!gAS65547')
-        assert mock_preloader.load_routes_into_memory.mock_calls
-
         assert not mock_dq.mock_calls
 
     def test_routes_for_origin_v6(self, prepare_parser):
@@ -971,7 +960,7 @@ class TestWhoisQueryParserIRRD:
             'sources_default': [],
             'rpki': {'roa_source': 'https://example.com/roa.json'},
         })
-        parser = WhoisQueryParser('127.0.0.1', '127.0.0.1:99999')
+        parser = WhoisQueryParser('127.0.0.1', '127.0.0.1:99999', mock_preloader)
 
         response = parser.handle_query('!r192.0.2.0/25')
         assert response.response_type == WhoisQueryResponseType.SUCCESS
@@ -1084,7 +1073,7 @@ class TestWhoisQueryParserIRRD:
             'sources_default': [],
             'rpki': {'roa_source': 'https://example.com/roa.json'}
         })
-        parser = WhoisQueryParser('127.0.0.1', '127.0.0.1:99999')
+        parser = WhoisQueryParser('127.0.0.1', '127.0.0.1:99999', mock_preloader)
         response = parser.handle_query('!s-lc')
         assert response.response_type == WhoisQueryResponseType.SUCCESS
         assert response.mode == WhoisQueryResponseMode.IRRD

--- a/irrd/server/whois/tests/test_server.py
+++ b/irrd/server/whois/tests/test_server.py
@@ -21,10 +21,7 @@ class MockSocket:
         self.close_called = False
 
     def makefile(self, mode, bufsize):
-        if 'w' in mode:
-            return self.wfile
-        else:
-            return self.rfile
+        return self.wfile if 'w' in mode else self.rfile
 
     def sendall(self, bytes):
         self.wfile.write(bytes)
@@ -64,6 +61,21 @@ class TestWhoisWorker:
         assert b'IRRd -- version' in request.wfile.read()
         assert request.shutdown_called
         assert request.close_called
+
+    def test_whois_request_worker_exception(self, create_worker, monkeypatch, caplog):
+        monkeypatch.setattr('irrd.server.whois.server.WhoisQueryParser',
+                            Mock(side_effect=OSError('expected')))
+
+        worker, request = create_worker
+        request.rfile.write(b'!v\r\n')
+        request.rfile.seek(0)
+        worker.run(keep_running=False)
+
+        request.wfile.seek(0)
+        assert not request.wfile.read()
+        assert request.shutdown_called
+        assert request.close_called
+        assert 'Failed to handle whois connection' in caplog.text
 
     def test_whois_request_worker_timeout(self, create_worker):
         worker, request = create_worker

--- a/irrd/server/whois/tests/test_server.py
+++ b/irrd/server/whois/tests/test_server.py
@@ -1,11 +1,10 @@
 import socket
 import time
-
+from io import BytesIO
 from queue import Queue
+from unittest.mock import Mock
 
 import pytest
-from io import BytesIO
-from unittest.mock import Mock
 
 from irrd.storage.preload import Preloader
 from ..server import WhoisWorker

--- a/irrd/storage/__init__.py
+++ b/irrd/storage/__init__.py
@@ -1,14 +1,36 @@
+import os
 import sqlalchemy as sa
 import ujson
 
-from sqlalchemy.pool import NullPool
-
 from irrd.conf import get_setting
+
+engine = None
 
 
 def get_engine():
-    return sa.create_engine(
+    global engine
+    if engine:
+        return engine
+    engine = sa.create_engine(
         get_setting('database_url'),
-        poolclass=NullPool,
+        pool_size=2,
         json_deserializer=ujson.loads,
     )
+
+    # https://docs.sqlalchemy.org/en/13/core/pooling.html#using-connection-pools-with-multiprocessing
+    @sa.event.listens_for(engine, "connect")
+    def connect(dbapi_connection, connection_record):
+        connection_record.info['pid'] = os.getpid()
+
+    @sa.event.listens_for(engine, "checkout")
+    def checkout(dbapi_connection, connection_record, connection_proxy):
+        pid = os.getpid()
+        if connection_record.info['pid'] != pid:
+            connection_record.connection = connection_proxy.connection = None
+            raise sa.exc.DisconnectionError(
+                    "Connection record belongs to pid %s, "
+                    "attempting to check out in pid %s" %
+                    (connection_record.info['pid'], pid)
+            )
+
+    return engine

--- a/irrd/storage/__init__.py
+++ b/irrd/storage/__init__.py
@@ -25,7 +25,7 @@ def get_engine():
     @sa.event.listens_for(engine, "checkout")
     def checkout(dbapi_connection, connection_record, connection_proxy):
         pid = os.getpid()
-        if connection_record.info['pid'] != pid:
+        if connection_record.info['pid'] != pid:  # pragma: no cover
             connection_record.connection = connection_proxy.connection = None
             raise sa.exc.DisconnectionError(
                     "Connection record belongs to pid %s, "

--- a/irrd/storage/__init__.py
+++ b/irrd/storage/__init__.py
@@ -28,9 +28,9 @@ def get_engine():
         if connection_record.info['pid'] != pid:  # pragma: no cover
             connection_record.connection = connection_proxy.connection = None
             raise sa.exc.DisconnectionError(
-                    "Connection record belongs to pid %s, "
-                    "attempting to check out in pid %s" %
-                    (connection_record.info['pid'], pid)
+                "Connection record belongs to pid %s, "
+                "attempting to check out in pid %s" %
+                (connection_record.info['pid'], pid)
             )
 
     return engine

--- a/irrd/storage/database_handler.py
+++ b/irrd/storage/database_handler.py
@@ -50,7 +50,7 @@ class DatabaseHandler:
         self.journaling_enabled = True
         self._connection = get_engine().connect()
         self._start_transaction()
-        self.preloader = Preloader()
+        self.preloader = Preloader(notification_only=True)
 
     def _start_transaction(self) -> None:
         """Start a fresh transaction."""

--- a/irrd/storage/database_handler.py
+++ b/irrd/storage/database_handler.py
@@ -50,7 +50,7 @@ class DatabaseHandler:
         self.journaling_enabled = True
         self._connection = get_engine().connect()
         self._start_transaction()
-        self.preloader = Preloader(notification_only=True)
+        self.preloader = Preloader(enable_queries=False)
 
     def _start_transaction(self) -> None:
         """Start a fresh transaction."""

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -51,7 +51,7 @@ class PersistentPubSubWorkerThread(redis.client.PubSubWorkerThread):  # type: ig
                     f'Failed redis pubsub connection, attempting reconnect and reload in 5s: {rce}')
                 time.sleep(5)
                 self.should_resubscribe = True
-            except Exception as exc:
+            except Exception as exc:  # pragma: no cover
                 logger.error(
                     f'Error while loading in-memory preload, attempting reconnect and reload in 5s, traceback follows: {exc}', exc_info=exc)
                 time.sleep(5)

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -105,7 +105,7 @@ class Preloader:
         Update the in-memory store. This is called whenever a
         message is sent to REDIS_PRELOAD_COMPLETE_CHANNEL.
         """
-        if redis_message and redis_message['type'] != 'message':
+        if redis_message and redis_message['type'] != 'message':  # pragma: no cover
             return
 
         while not self._redis_conn.exists(REDIS_ORIGIN_ROUTE4_STORE_KEY):

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -53,7 +53,7 @@ class Preloader:
         if enable_queries:
             self._pubsub = self._redis_conn.pubsub()
             self._pubsub.subscribe(**{REDIS_PRELOAD_COMPLETE_CHANNEL: self._load_routes_into_memory})
-            self._pubsub_thread = self._pubsub.run_in_thread(sleep_time=1)
+            self._pubsub_thread = self._pubsub.run_in_thread(sleep_time=1, daemon=True)
 
     def signal_reload(self, object_classes_changed: Optional[Set[str]]=None) -> None:
         """
@@ -105,9 +105,6 @@ class Preloader:
         Update the in-memory store. This is called whenever a
         message is sent to REDIS_PRELOAD_COMPLETE_CHANNEL.
         """
-        if redis_message and redis_message['type'] != 'message':  # pragma: no cover
-            return
-
         while not self._redis_conn.exists(REDIS_ORIGIN_ROUTE4_STORE_KEY):
             time.sleep(1)  # pragma: no cover
         logger.debug('Preloader (re)loading routes locally into memory')

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -125,10 +125,8 @@ class Preloader:
             return set()
 
         prefix_sets: Set[str] = set()
-        for source_str in sources:
-            source = source_str.encode('ascii')
-            for origin_str in origins:
-                origin = origin_str.encode('ascii')
+        for source in sources:
+            for origin in origins:
                 if (not ip_version or ip_version == 4) and source in self._origin_route4_store and origin in self._origin_route4_store[source]:
                     prefix_sets.update(self._origin_route4_store[source][origin].split(REDIS_ORIGIN_LIST_SEPARATOR))
                 if (not ip_version or ip_version == 6) and source in self._origin_route6_store and origin in self._origin_route6_store[source]:
@@ -149,13 +147,12 @@ class Preloader:
 
         self._origin_route4_store = dict()
         self._origin_route6_store = dict()
-        source_separator = REDIS_KEY_ORIGIN_SOURCE_SEPARATOR.encode('ascii')
 
         def _load(redis_key, target):
             for key, routes in self._redis_conn.hgetall(redis_key).items():
                 if key == SENTINEL_HASH_CREATED:
                     continue
-                source, origin = key.split(source_separator)
+                source, origin = key.decode('ascii').split(REDIS_KEY_ORIGIN_SOURCE_SEPARATOR)
                 if source not in target:
                     target[source] = dict()
                 target[source][origin] = routes.decode('ascii')

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -289,18 +289,15 @@ class PreloadUpdater(threading.Thread):
         new_origin_route4_store: Dict[str, set] = defaultdict(set)
         new_origin_route6_store: Dict[str, set] = defaultdict(set)
 
-        print('initialising DH')
         if not mock_database_handler:  # pragma: no cover
             from .database_handler import DatabaseHandler
             dh = DatabaseHandler()
         else:
             dh = mock_database_handler
 
-        print('about to run query')
         q = RPSLDatabaseQuery(column_names=['ip_version', 'ip_first', 'prefix_length', 'asn_first', 'source'], enable_ordering=False)
         q = q.object_classes(['route', 'route6']).rpki_status([RPKIStatus.not_found, RPKIStatus.valid])
 
-        print('executing')
         for result in dh.execute_query(q):
             prefix = result['ip_first']
             key = result['source'] + REDIS_KEY_ORIGIN_SOURCE_SEPARATOR + 'AS' + str(result['asn_first'])
@@ -311,7 +308,6 @@ class PreloadUpdater(threading.Thread):
             if result['ip_version'] == 6:
                 new_origin_route6_store[key].add(f'{prefix}/{length}')
 
-        print('completed query')
         dh.close()
 
         if self.preloader.update_route_store(new_origin_route4_store, new_origin_route6_store):

--- a/irrd/storage/tests/test_database.py
+++ b/irrd/storage/tests/test_database.py
@@ -42,7 +42,7 @@ def irrd_database(monkeypatch):
                         f'to overwrite existing database.')
     RPSLDatabaseObject.metadata.create_all(engine)
 
-    monkeypatch.setattr('irrd.storage.database_handler.Preloader', lambda: Mock(spec=Preloader))
+    monkeypatch.setattr('irrd.storage.database_handler.Preloader', lambda enable_queries: Mock(spec=Preloader))
 
     yield None
 

--- a/irrd/storage/tests/test_preload.py
+++ b/irrd/storage/tests/test_preload.py
@@ -117,7 +117,6 @@ class TestPreloading:
         assert 'Invalid IP version: 2' in str(ve.value)
 
 
-
 class TestPreloadUpdater:
     def test_preload_updater(self, monkeypatch):
         mock_database_handler = Mock(spec=DatabaseHandler)

--- a/irrd/storage/tests/test_preload.py
+++ b/irrd/storage/tests/test_preload.py
@@ -14,6 +14,7 @@ from ..queries import RPSLDatabaseQuery
 TEST_REDIS_ORIGIN_ROUTE4_STORE_KEY = 'TEST-irrd-preload-origin-route4'
 TEST_REDIS_ORIGIN_ROUTE6_STORE_KEY = 'TEST-irrd-preload-origin-route6'
 TEST_REDIS_PRELOAD_RELOAD_CHANNEL = 'TEST-irrd-preload-reload-channel'
+TEST_REDIS_PRELOAD_COMPLETE_CHANNEL = 'TEST-irrd-preload-complete-channel'
 
 
 @pytest.fixture()
@@ -28,6 +29,7 @@ def mock_redis_keys(monkeypatch, config_override):
     monkeypatch.setattr('irrd.storage.preload.REDIS_ORIGIN_ROUTE4_STORE_KEY', TEST_REDIS_ORIGIN_ROUTE4_STORE_KEY)
     monkeypatch.setattr('irrd.storage.preload.REDIS_ORIGIN_ROUTE6_STORE_KEY', TEST_REDIS_ORIGIN_ROUTE6_STORE_KEY)
     monkeypatch.setattr('irrd.storage.preload.REDIS_PRELOAD_RELOAD_CHANNEL', TEST_REDIS_PRELOAD_RELOAD_CHANNEL)
+    monkeypatch.setattr('irrd.storage.preload.REDIS_PRELOAD_COMPLETE_CHANNEL', TEST_REDIS_PRELOAD_COMPLETE_CHANNEL)
 
 
 class TestPreloading:
@@ -113,6 +115,7 @@ class TestPreloading:
         with pytest.raises(ValueError) as ve:
             preloader.routes_for_origins(['AS65547'], [], 2)
         assert 'Invalid IP version: 2' in str(ve.value)
+
 
 
 class TestPreloadUpdater:


### PR DESCRIPTION
This should improve upon #338 

The new model so far is:
- Long-running worker processes, so no forking delay
- Each worker has a database connection pool, so no connection delay
- Each worker keeps a local copy of the preload data in memory. This is taken from the redis store, to prevent each worker from having to retrieve the full data from the database to update its local preload data, which is way heavier than loading the small redis data into memory. An additional pubsub channel is used to trigger updates
- Limitation: worker processes can only handle a single whois client connection at a time due to them having state
- The first query a single worker answers still seems to have a 10-50ms delay, but this only applies for the first query on the first connection to a long-running worker.

Todo:
- [x] Fix tests
- [x] Look into resource usage of the workers
- [x] Verify that a Redis restart is still recoverable
- [x] Add documentation on memory usage
- [x] Do a longer test run
- [x] Clean up