### PR TITLE
Fix #335 - End RIPE-style whois responses with two empty lines.

### DIFF
--- a/docs/releases/4.1.0.rst
+++ b/docs/releases/4.1.0.rst
@@ -86,6 +86,8 @@ Other changes
 * A number of new configuration options were added, and some are required.
   See the :doc:`configuration documentation </admins/configuration>` for more
   information on these options.
+* RIPE style query responses now always end with two empty lines,
+  `consistent with the RIPE database`_.
 * A timeout was added for FTP connections.
 * A bug was fixed where some invalid objects could cause parser exceptions.
 
@@ -122,3 +124,5 @@ whether RPKI-aware mode is enabled or not.
 * Ensure that RPKI-aware mode is configured as desired. By default it is
   **enabled**.
 * Start IRRd and re-enable the cron / e-mail triggered tasks.
+
+.. _consistent with the RIPE database: https://www.ripe.net/manage-ips-and-asns/db/support/documentation/ripe-database-query-reference-manual#2-0-querying-the-ripe-database

--- a/docs/users/queries.rst
+++ b/docs/users/queries.rst
@@ -140,6 +140,9 @@ The query::
 will set the client name to `my-client` and return all as-sets named
 `AS-EXAMPLE`.
 
+RIPE style queries always end with two empty lines, i.e.
+two newline characters.
+
 Queries
 ^^^^^^^
 * ``-l``, ``-L``, ``-M`` and ``-x`` search for `route` or `route6` objects.

--- a/irrd/server/whois/query_response.py
+++ b/irrd/server/whois/query_response.py
@@ -74,12 +74,15 @@ class WhoisQueryResponse:
         return None
 
     def _generate_response_ripe(self) -> Optional[str]:
+        # RIPE-style responses need two empty lines at the end, hence
+        # the multiple newlines for each response (#335)
+        # # https://www.ripe.net/manage-ips-and-asns/db/support/documentation/ripe-database-query-reference-manual#2-0-querying-the-ripe-database
         if self.response_type == WhoisQueryResponseType.SUCCESS:
             if self.result:
-                return self.result + '\n\n'
-            return '%  No entries found for the selected source(s).\n'
+                return self.result + '\n\n\n'
+            return '%  No entries found for the selected source(s).\n\n\n'
         elif self.response_type == WhoisQueryResponseType.KEY_NOT_FOUND:
-            return '%  No entries found for the selected source(s).\n'
+            return '%  No entries found for the selected source(s).\n\n\n'
         elif self.response_type == WhoisQueryResponseType.ERROR:
-            return f'%% ERROR: {self.result}\n'
+            return f'%% ERROR: {self.result}\n\n\n'
         return None

--- a/irrd/server/whois/tests/test_query_response.py
+++ b/irrd/server/whois/tests/test_query_response.py
@@ -30,19 +30,19 @@ class TestWhoisQueryResponse:
         response = WhoisQueryResponse(mode=WhoisQueryResponseMode.RIPE,
                                       response_type=WhoisQueryResponseType.SUCCESS,
                                       result='test').generate_response()
-        assert response == 'test\n\n'
+        assert response == 'test\n\n\n'
         response = WhoisQueryResponse(mode=WhoisQueryResponseMode.RIPE,
                                       response_type=WhoisQueryResponseType.SUCCESS,
                                       result='').generate_response()
-        assert response == '%  No entries found for the selected source(s).\n'
+        assert response == '%  No entries found for the selected source(s).\n\n\n'
         response = WhoisQueryResponse(mode=WhoisQueryResponseMode.RIPE,
                                       response_type=WhoisQueryResponseType.KEY_NOT_FOUND,
                                       result='test').generate_response()
-        assert response == '%  No entries found for the selected source(s).\n'
+        assert response == '%  No entries found for the selected source(s).\n\n\n'
         response = WhoisQueryResponse(mode=WhoisQueryResponseMode.RIPE,
                                       response_type=WhoisQueryResponseType.ERROR,
                                       result='test').generate_response()
-        assert response == '%% ERROR: test\n'
+        assert response == '%% ERROR: test\n\n\n'
 
         with raises(RuntimeError) as ve:
             # noinspection PyTypeChecker


### PR DESCRIPTION
As documented in https://www.ripe.net/manage-ips-and-asns/db/support/documentation/ripe-database-query-reference-manual#2-0-querying-the-ripe-database

Co-authored-by: Stefan Eissing <stefan.eissing@greenbytes.de>