### PR TITLE
Fix #342 - Read RPSL files iteratively, reducing IRRd memory usage.

### DIFF
--- a/irrd/utils/text.py
+++ b/irrd/utils/text.py
@@ -42,7 +42,7 @@ def split_paragraphs_rpsl(input: Union[str, TextIO], strip_comments=True) -> Ite
     if isinstance(input, str):
         generator = splitline_unicodesafe(input)
     else:
-        generator = iter(input.readlines())
+        generator = input
 
     for line in generator:
         line = line.strip('\r\n')


### PR DESCRIPTION
Co-authored-by: Stefan Eissing <stefan.eissing@greenbytes.de>