### PR TITLE
Add Docker files to build IRRd image on release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.6-alpine
+
+COPY ./ /var/cache/irrd
+
+RUN apk update \
+ && apk add --no-cache --virtual .build-deps \
+        build-base musl-dev gcc python3 python3-dev postgresql-dev \
+ && pip install --no-cache-dir cython /var/cache/irrd \
+ && rm -rf /var/cache/irrd \
+ && apk del --no-cache .build-deps \
+ && apk add gnupg postgresql
+
+CMD ["/usr/local/bin/irrd"]

--- a/Dockerignore
+++ b/Dockerignore
@@ -1,0 +1,6 @@
+docs
+.git*
+.circleci
+.github
+.coveragerc
+.pyup.yml


### PR DESCRIPTION
Not sure this is still something we want (https://github.com/irrdnet/irrd/issues/13), opening this PR to add the Docker files to build images on IRRd release. Could go nice with the Docker Hub builds, to trigger builds and publish the images on tags and PR merge.
Let me know what you think.