### PR TITLE
Fix #381 - Fix corrupt gzip files on OpenBSD

### DIFF
--- a/irrd/mirroring/mirror_runners_export.py
+++ b/irrd/mirroring/mirror_runners_export.py
@@ -58,7 +58,7 @@ class SourceExportRunner:
         except StopIteration:
             serial = None
 
-        with gzip.open(export_tmpfile, 'wb') as fh:
+        with gzip.open(export_tmpfile.name, 'wb') as fh:
             query = RPSLDatabaseQuery().sources([self.source])
             query = query.rpki_status([RPKIStatus.not_found, RPKIStatus.valid])
             query = query.scopefilter_status([ScopeFilterStatus.in_scope])


### PR DESCRIPTION
The API for the gzip module suggests that passing a file descriptor
instead of a filename should work, but on OpenBSD a running IRRd
instance will produce corrupt gzip files without this change.
This was also not reproducible in the tests.