### PR TITLE
Switch from ftplib to urllib for FTP downloads.

### DIFF
--- a/docs/releases/4.2.0.rst
+++ b/docs/releases/4.2.0.rst
@@ -5,5 +5,7 @@ Release notes for IRRd 4.2.0
 * The optional ``geofeed`` attribute was added for `inetnum` and `inet6num`
   objects, which can contain a URL which in turn contains geographical
   information, as defined in `draft-ymbk-opsawg-finding-geofeeds-03`_.
+* Retrieval of files over FTP now follows the ``ftp_proxy`` environment
+  variable, if set.
 
 .. _draft-ymbk-opsawg-finding-geofeeds-03: https://tools.ietf.org/html/draft-ymbk-opsawg-finding-geofeeds-03


### PR DESCRIPTION
urllib supports HTTP proxies for FTP out of the box using
standard ftp_proxy environment variables.

Tested with ftp.radb.net mirroring through an HTTP proxy.