### PR TITLE
Ref #451 - Terminate startup if workers fail to start

### DIFF
--- a/irrd/__init__.py
+++ b/irrd/__init__.py
@@ -1,1 +1,2 @@
 __version__ = '4.2.0a1'
+ENV_MAIN_PROCESS_PID = 'IRRD_MAIN_PROCESS_PID'

--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -15,7 +15,7 @@ from pid import PidFile, PidFileError
 logger = logging.getLogger(__name__)
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-from irrd import __version__
+from irrd import __version__, ENV_MAIN_PROCESS_PID
 from irrd.conf import config_init, CONFIG_PATH_DEFAULT, get_setting, get_configuration
 from irrd.mirroring.scheduler import MirrorScheduler
 from irrd.server.http.server import run_http_server
@@ -67,6 +67,7 @@ def main():
 
 def run_irrd(mirror_frequency: int, config_file_path: str):
     terminated = False
+    os.environ[ENV_MAIN_PROCESS_PID] = str(os.getpid())
 
     mirror_scheduler = MirrorScheduler()
     whois_process = ExceptionLoggingProcess(target=start_whois_server, name='irrd-whois-server-listener')


### PR DESCRIPTION
If the whois or HTTP workers fail to connect to the database
or preloader on startup, they will send a termination signal
to the main process, terminating IRRd. This prevents starting
up in a broken state.

This does not change behaviour afterwards: if the connection
is lost later, the workers will fail the current query after one
reconnection attempt. They will again attempt reconnection
on future queries. This allows IRRd to recover from a
PostgreSQL restart.