### PR TITLE
Add support for resolving duplicate sets

### DIFF
--- a/docs/users/queries/graphql.rst
+++ b/docs/users/queries/graphql.rst
@@ -366,6 +366,7 @@ The response type is::
 
     type SetMembers {
       rpslPk: String!
+      rootSource: String!
       members: [String!]
     }
 
@@ -374,11 +375,16 @@ and return the result for each resolved set separately.
 You can also limit the recursion depth,
 or exclude certain sets from consideration.
 
+If there are multiple sets with the same name in different sources, this
+query will return each of them along with their members, with a different
+``rootSource``.
+
 An example query::
 
     query {
       recursiveSetMembers(setNames: ["RS-KROOT-LINX"]) {
         rpslPk
+        rootSource
         members
       }
     }

--- a/irrd/integration_tests/run.py
+++ b/irrd/integration_tests/run.py
@@ -661,6 +661,7 @@ class TestIntegration:
         query = """query {
           recursiveSetMembers(setNames: ["AS65537:AS-TESTREF"]) {
             rpslPk
+            rootSource
             members
           }
         }
@@ -669,6 +670,7 @@ class TestIntegration:
         recursiveSetMembers = result['data']['recursiveSetMembers']
         assert len(recursiveSetMembers) == 1
         assert recursiveSetMembers[0]['rpslPk'] == 'AS65537:AS-TESTREF'
+        assert recursiveSetMembers[0]['rootSource'] == 'TEST'
         assert set(recursiveSetMembers[0]['members']) == {
             'AS65537', 'AS65538', 'AS65539', 'AS65540'
         }

--- a/irrd/server/graphql/resolvers.py
+++ b/irrd/server/graphql/resolvers.py
@@ -291,8 +291,9 @@ def resolve_recursive_set_members(_, info: GraphQLResolveInfo, set_names: List[s
     exclude_sets_set = {i.upper() for i in exclude_sets} if exclude_sets else set()
     query_resolver.set_query_sources(sources)
     for set_name in set_names_set:
-        members = list(query_resolver.members_for_set(set_name, exclude_sets=exclude_sets_set, depth=depth, recursive=True))
-        yield dict(rpslPk=set_name, members=members)
+        results = query_resolver.members_for_set_per_source(set_name, exclude_sets=exclude_sets_set, depth=depth, recursive=True)
+        for source, members in results.items():
+            yield dict(rpslPk=set_name, rootSource=source, members=members)
     if sql_trace:
         info.context['sql_queries'] = query_resolver.retrieve_sql_trace()
 

--- a/irrd/server/graphql/schema_generator.py
+++ b/irrd/server/graphql/schema_generator.py
@@ -92,6 +92,7 @@ class SchemaGenerator:
 
             type SetMembers {
                 rpslPk: String!
+                rootSource: String!
                 members: [String!]
             }
         """

--- a/irrd/server/graphql/tests/test_resolvers.py
+++ b/irrd/server/graphql/tests/test_resolvers.py
@@ -372,7 +372,7 @@ class TestGraphQLResolvers:
 
     def test_resolve_recursive_set_members(self, prepare_resolver):
         info, mock_database_query, mock_query_resolver = prepare_resolver
-        mock_query_resolver.members_for_set = lambda set_name, exclude_sets, depth, recursive: [f'member-{set_name}']
+        mock_query_resolver.members_for_set_per_source = lambda set_name, exclude_sets, depth, recursive: {'TEST1': [f'member1-{set_name}'], 'TEST2': [f'member2-{set_name}']}
 
         result = list(resolvers.resolve_recursive_set_members(
             None,
@@ -382,7 +382,9 @@ class TestGraphQLResolvers:
             sql_trace=True,
         ))
         assert sorted(result, key=str) == sorted([
-            {'rpslPk': 'AS-A', 'members': ['member-AS-A']},
-            {'rpslPk': 'AS-B', 'members': ['member-AS-B']},
+            {'rpslPk': 'AS-A', 'rootSource': 'TEST1', 'members': ['member1-AS-A']},
+            {'rpslPk': 'AS-A', 'rootSource': 'TEST2', 'members': ['member2-AS-A']},
+            {'rpslPk': 'AS-B', 'rootSource': 'TEST1', 'members': ['member1-AS-B']},
+            {'rpslPk': 'AS-B', 'rootSource': 'TEST2', 'members': ['member2-AS-B']},
         ], key=str)
         mock_query_resolver.set_query_sources.assert_called_once()

--- a/irrd/server/graphql/tests/test_schema_generator.py
+++ b/irrd/server/graphql/tests/test_schema_generator.py
@@ -73,6 +73,7 @@ enum ScopeFilterStatus {
 
             type SetMembers {
                 rpslPk: String!
+                rootSource: String!
                 members: [String!]
             }
         interface RPSLObject {

--- a/irrd/server/query_resolver.py
+++ b/irrd/server/query_resolver.py
@@ -132,7 +132,7 @@ class QueryResolver:
     def members_for_set_per_source(self, parameter: str, exclude_sets: Set[str]=None, depth=0, recursive=False) -> Dict[str, List[str]]:
         """
         Find all members of an as-set or route-set, possibly recursively, distinguishing
-        between multiple objects in different sources with the same name.
+        between multiple root objects in different sources with the same name.
         Returns a dict with sources as keys, list of all members, including leaf members,
         as values.
         """

--- a/irrd/server/tests/test_query_resolver.py
+++ b/irrd/server/tests/test_query_resolver.py
@@ -582,7 +582,17 @@ class TestQueryResolver:
                     'pk': uuid.uuid4(),
                     'rpsl_pk': 'AS-TEST',
                     'parsed_data': {'as-set': 'AS-TEST',
-                                    'members': ['AS65547']},
+                                    'members': ['AS65547', 'AS-SECONDLEVEL']},
+                    'object_text': 'text',
+                    'object_class': 'as-set',
+                    'source': 'TEST1',
+                },
+            ], [
+                {
+                    'pk': uuid.uuid4(),
+                    'rpsl_pk': 'AS-SECONDLEVEL',
+                    'parsed_data': {'as-set': 'AS-SECONDLEVEL',
+                                    'members': ['AS65548']},
                     'object_text': 'text',
                     'object_class': 'as-set',
                     'source': 'TEST1',
@@ -592,27 +602,30 @@ class TestQueryResolver:
                     'pk': uuid.uuid4(),
                     'rpsl_pk': 'AS-TEST',
                     'parsed_data': {'as-set': 'AS-TEST',
-                                    'members': ['AS65548']},
+                                    'members': ['AS65549']},
                     'object_text': 'text',
                     'object_class': 'as-set',
                     'source': 'TEST2',
                 },
-            ]
+            ],
+            [],
         ])
 
         mock_dh.execute_query = lambda query, refresh_on_error=False: next(mock_query_result)
 
-        result = resolver.members_for_set_per_source('AS-TEST', recursive=False)
-        assert result == {'TEST1': ['AS65547'], 'TEST2': ['AS65548']}
+        result = resolver.members_for_set_per_source('AS-TEST', recursive=True)
+        assert result == {'TEST1': ['AS65547', 'AS65548'], 'TEST2': ['AS65549']}
         assert flatten_mock_calls(mock_dq) == [
             ['object_classes', (['as-set', 'route-set'],), {}],
             ['rpsl_pk', ('AS-TEST',), {}],
             ['object_classes', (['as-set', 'route-set'],), {}],
             ['rpsl_pks', ({'AS-TEST'},), {}],
             ['sources', (['TEST1'],), {}],
+            ['object_classes', (['as-set'],), {}],
+            ['rpsl_pks', ({'AS-SECONDLEVEL'},), {}],
             ['object_classes', (['as-set', 'route-set'],), {}],
             ['rpsl_pks', ({'AS-TEST'},), {}],
-            ['sources', (['TEST2'],), {}],
+            ['sources', (['TEST2'],), {}]
         ]
         mock_dq.reset_mock()
 


### PR DESCRIPTION
In cases where multiple sets exist with the same
name in different sources, the GraphQL API will
resolve each independently, rather than only the
one that comes first in the source order.

This will allow support for https://github.com/dashcare/irrexplorer/issues/52
and can also be helpful for any other tools working with IRR sets.