### PR TITLE
Fix issue where workers could end up with empty preload store

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.7-stretch
+      - image: cimg/python:3.6
         environment:
           IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
           IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
@@ -33,21 +33,22 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v4-dependencies-{{ checksum "requirements.txt" }}
+          - v5-dependencies-{{ checksum "requirements.txt" }}
           # fallback to using the latest cache if no exact match is found
-          - v4-dependencies-
+          - v5-dependencies-
 
       - run:
           name: install dependencies
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install -U pip
             pip install -r requirements.txt
 
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v5-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: apt update
@@ -58,7 +59,7 @@ jobs:
 
       - run:
           name: Installing psql client and enchant
-          command: sudo apt install postgresql-client python-enchant
+          command: sudo apt install postgresql-client python3-enchant
 
       - run:
           name: Waiting for PostgreSQL to be ready

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -146,8 +146,8 @@ class Preloader:
         # Create a bit of randomness in when workers will update
         time.sleep(random.random())
 
-        self._origin_route4_store = dict()
-        self._origin_route6_store = dict()
+        new_origin_route4_store = dict()
+        new_origin_route6_store = dict()
 
         def _load(redis_key, target):
             for key, routes in self._redis_conn.hgetall(redis_key).items():
@@ -158,8 +158,11 @@ class Preloader:
                     target[source] = dict()
                 target[source][origin] = routes.decode('ascii')
 
-        _load(REDIS_ORIGIN_ROUTE4_STORE_KEY, self._origin_route4_store)
-        _load(REDIS_ORIGIN_ROUTE6_STORE_KEY, self._origin_route6_store)
+        _load(REDIS_ORIGIN_ROUTE4_STORE_KEY, new_origin_route4_store)
+        _load(REDIS_ORIGIN_ROUTE6_STORE_KEY, new_origin_route6_store)
+
+        self._origin_route4_store = new_origin_route4_store
+        self._origin_route6_store = new_origin_route6_store
 
         self._memory_loaded = True
 


### PR DESCRIPTION
Directly into 4.1.x due to ongoing issues in production deployment