### PR TITLE
Fix #575 - Add extended set validation

### DIFF
--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -390,7 +390,6 @@ keys in turn override settings under the ``COMMON`` key.
 |br| **Change takes effect**: upon the next update attempt.
 
 
-
 Access lists
 ~~~~~~~~~~~~
 * ``access_lists.{list_name}``: a list of permitted IPv4 and/or IPv6 addresses

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -349,41 +349,44 @@ without a prefix or with one, per ``prefix_required``.
 But if it has a prefix, there *must* be a corresponding
 aut-num object for which authentication *must* pass, per ``autnum_authentication``.
 
-You can configure one default for all set classes under the key ``DEFAULT``,
+You can configure one common for all set classes under the key ``COMMON``,
 and/or specific settings for specific classes using the class name as key.
 An example::
 
     irrd:
       auth:
           set_creation:
-              DEFAULT:
-                  prefix_required: true
-                  autnum_authentication: opportunistic
-              as-set:
+              COMMON:
                   prefix_required: true
                   autnum_authentication: required
+              as-set:
+                  prefix_required: true
+                  autnum_authentication: opportunistic
               rtr-set:
                   prefix_required: false
                   autnum_authentication: disabled
 
 This example means:
 
-* New ``as-set`` objects must include an ASN prefix in their name, an `aut-num`
-  corresponding that AS number must exist, and the user must pass authentication
-  for that `aut-num` object.
+* New `as-set` objects must include an ASN prefix in their name
+  and the user must pass authentication for the corresponding `aut-num` object,
+  if it exists. If the `aut-num` does not exist, the check passes.
 * New ``rtr-set`` objects are not required to include an ASN prefix in their
   name, but this is permitted. The user never has to pass authentication for
   the corresponding `aut-num` object, regardless of whether it exists.
-* All other new set objects must include an ASN prefix in their name
-  and the user must pass authentication for the corresponding `aut-num` object,
-  if it exists. If the `aut-num` does not exist, the check passes.
+* All other new set objects must include an ASN prefix in their name, an `aut-num`
+  corresponding that AS number must exist, and the user must pass authentication
+  for that `aut-num` object.
 
 All checks are only applied when users create new set objects in authoritative
 databases. Authoritative updates to existing objects, deletions, or objects from
 mirrors are never affected. When looking for corresponding `aut-num` objects,
 IRRd only looks in the same IRR source.
 
-|br| **Default**: TODO
+**Default**: ``prefix_required`` is enabled, ``autnum_authentication``
+set to ``opportunistic`` for all sets. Note that settings under the
+``COMMON`` key override these IRRd defaults, and settings under set-specific
+keys in turn override settings under the ``COMMON`` key.
 |br| **Change takes effect**: upon the next update attempt.
 
 

--- a/docs/releases/4.1.0.rst
+++ b/docs/releases/4.1.0.rst
@@ -96,7 +96,7 @@ Other changes
   for further details.
 * When users create `route(6)` objects in authoritative databases, IRRd
   also verifies authorisation from
-  :ref:`related object maintainers <auth-related-mntners>`. This behaviour
+  :ref:`related object maintainers <auth-related-mntners-route>`. This behaviour
   is enabled by default, but can be disabled with the
   ``auth.authenticate_related_mntners`` setting.
 * The ``!j`` command has changed, and now is exclusively used to check

--- a/docs/releases/4.3.0.rst
+++ b/docs/releases/4.3.0.rst
@@ -2,4 +2,39 @@
 Release notes for IRRd 4.3.0
 ============================
 
-* removal of compatibility.permit_non_hierarchical_as_set_name
+Changes to related object authentication and settings
+-----------------------------------------------------
+In version 4.2, IRRd required newly created authoritative `as-set` objects
+to have a hierarchical name where the first element is an AS number.
+In 4.3, this feature has been significantly expanded.
+
+For all RPSL set objects, IRRd can now be configured to require:
+
+* Including an ASN prefix in the name of the set, e.g. ``AS65537:AS-EXAMPLE``
+  being valid, but ``AS-EXAMPLE`` being invalid.
+* Passing authentication for the corresponding `aut-num`, e.g. AS65537 in the
+  last example, skipping this check if the `aut-num` does not exist.
+* Passing authentication for the corresponding `aut-num`, e.g. AS65537 in the
+  last example, failing this check if the `aut-num` does not exist.
+
+The first two options, requiring a prefix with opportunistic `aut-num` authentication,
+is now the default for all set objects.
+You can :ref:`change the configuration <conf-auth-set-creation>` for specific
+RPSL set objects, or set your own common configuration that applies to all sets.
+
+The ``compatibility.permit_non_hierarchical_as_set_name`` setting has been
+removed, as it is now covered by the ``prefix_required`` setting.
+
+The ``auth.authenticate_related_mntners`` setting has been renamed to 
+``auth.authenticate_parents_route_creation``, as this setting exclusively
+relates to :ref:`authentication for route(6) objects <auth-related-mntners-route>`
+and needs to be distinct from the configuration for RPSL set objects.
+
+If you were using ``auth.authenticate_related_mntners`` or 
+``compatibility.permit_non_hierarchical_as_set_name``, you need to update
+your configuration.
+
+All checks are only applied when users create new set objects in authoritative
+databases. Authoritative updates to existing objects, deletions, or objects from
+mirrors are never affected. When looking for related objects,
+IRRd only looks in the same IRR source.

--- a/docs/releases/4.3.0.rst
+++ b/docs/releases/4.3.0.rst
@@ -1,0 +1,5 @@
+============================
+Release notes for IRRd 4.3.0
+============================
+
+* removal of compatibility.permit_non_hierarchical_as_set_name

--- a/docs/releases/4.3.0.rst
+++ b/docs/releases/4.3.0.rst
@@ -13,9 +13,9 @@ For all RPSL set objects, IRRd can now be configured to require:
 * Including an ASN prefix in the name of the set, e.g. ``AS65537:AS-EXAMPLE``
   being valid, but ``AS-EXAMPLE`` being invalid.
 * Passing authentication for the corresponding `aut-num`, e.g. AS65537 in the
-  last example, skipping this check if the `aut-num` does not exist.
+  example, skipping this check if the `aut-num` does not exist.
 * Passing authentication for the corresponding `aut-num`, e.g. AS65537 in the
-  last example, failing this check if the `aut-num` does not exist.
+  example, failing this check if the `aut-num` does not exist.
 
 The first two options, requiring a prefix with opportunistic `aut-num` authentication,
 is now the default for all set objects.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,5 +1,7 @@
 ASes
+aut
 CPython
+customisable
 Escribano
 IPtables
 IPv
@@ -46,6 +48,7 @@ nginx
 noreply
 nrtm
 ntt
+num
 ov
 pidfile
 postgres

--- a/docs/users/database-changes.rst
+++ b/docs/users/database-changes.rst
@@ -303,9 +303,9 @@ include a requirement to:
 * Include an ASN prefix in the name of your set, e.g. ``AS65537:AS-EXAMPLE``
   being valid, but ``AS-EXAMPLE`` being invalid.
 * Pass authentication for the corresponding `aut-num`, e.g. AS65537 in the
-  last example, skipping this check if the `aut-num` does not exist.
+  example, skipping this check if the `aut-num` does not exist.
 * Pass authentication for the corresponding `aut-num`, e.g. AS65537 in the
-  last example, failing this check if the `aut-num` does not exist.
+  example, failing this check if the `aut-num` does not exist.
 
 These requirements do not apply when you change or delete existing objects.
 When looking for corresponding `aut-num` objects,

--- a/docs/users/database-changes.rst
+++ b/docs/users/database-changes.rst
@@ -269,11 +269,13 @@ When you create a new `mntner`, a submission must pass authorisation for
 one of the auth methods of the new mntner. You can submit other objects
 that depend on the new `mntner` in the same submission.
 
-.. _auth-related-mntners:
+.. _auth-related-mntners-route:
 
+Related maintainers in route objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When you create new `route(6)` objects, authentication also needs to pass
 for the parent object. IRRd searches for the parent object in the following
-order, only considering the first match:
+order, only considering the first match, only looking in the same IRR source:
 
 * An `inet(6)num` that is an exact match to the new `route(6)`.
 * The smallest `inet(6)num` that is a less specific of the new `route(6)`.
@@ -282,7 +284,32 @@ order, only considering the first match:
 If no objects match, there is no parent object, and there are no extra
 authentication requirements.
 This behaviour can be disabled by setting
-``auth.authenticate_related_mntners`` to false.
+``auth.authenticate_parents_route_creation`` to false.
+These requirements do not apply when you change or delete existing objects.
+
+.. _auth-related-mntners-set:
+
+Related maintainers in set objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When you create new set objects, you may need to pass authentication for the
+parent `aut-num` object.
+RPSL set objects are `as-set`, `filter-set`, `peering-set`, `route-set` and
+`rtr-set`.
+
+The details of this behaviour and the strictness of the checks are
+:ref:`configured by the IRR operator <conf-auth-set-creation>`. This may
+include a requirement to:
+
+* Include an ASN prefix in the name of your set, e.g. ``AS65537:AS-EXAMPLE``
+  being valid, but ``AS-EXAMPLE`` being invalid.
+* Pass authentication for the corresponding `aut-num`, e.g. AS65537 in the
+  last example, skipping this check if the `aut-num` does not exist.
+* Pass authentication for the corresponding `aut-num`, e.g. AS65537 in the
+  last example, failing this check if the `aut-num` does not exist.
+
+These requirements do not apply when you change or delete existing objects.
+When looking for corresponding `aut-num` objects,
+IRRd only looks in the same IRR source.
 
 Object templates
 ----------------
@@ -323,12 +350,12 @@ This template shows:
 * The `member-of` attribute is a look-up key, meaning it can be used with
   ``-i`` queries.
 * The `member-of` attribute references to the `route-set` class. It is a
-  weak references, meaning the referred `route-set` does not have to exist,
+  weak reference, meaning the referred `route-set` does not have to exist,
   but is required to meet the syntax of a `route-set` name. The attribute
   is also optional, so it can be left out entirely.
 * The `admin-c` and `tech-c` attributes reference a `role` or `person`.
   This means they may refer to either object class, but must be a
-  reference to a valid, existing `person` or `role. This `person` or
+  reference to a valid, existing `person` or `role`. This `person` or
   `role` can be created as part of the same submission.
 
 

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -213,7 +213,7 @@ class Configuration:
         config = self.user_config_staging
 
         def _validate_subconfig(key, value):
-            if hasattr(value, 'items'):
+            if isinstance(value, (DottedDict, dict)):
                 for key2, value2 in value.items():
                     subkey = key + '.' + key2
                     known_sub = self.known_config_keys.get(subkey)
@@ -225,9 +225,7 @@ class Configuration:
         for key, value in config.items():
             if key in ['sources', 'access_lists']:
                 continue
-            known = self.known_config_keys.get(key)
-
-            if known is None:
+            if self.known_config_keys.get(key) is None:
                 errors.append(f'Unknown setting key: {key}')
             _validate_subconfig(key, value)
 

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 PASSWORD_HASH_DUMMY_VALUE = 'DummyValue'
 SOURCE_NAME_RE = re.compile('^[A-Z][A-Z0-9-]*[A-Z0-9]$')
 RPKI_IRR_PSEUDO_SOURCE = 'RPKI'
-VALID_SET_AUTNUM_AUTHENTICATION = ['disabled', 'opportunistic', 'required']
+
 
 LOGGING = {
     'version': 1,
@@ -265,11 +265,13 @@ class Configuration:
         if not self._check_is_str(config, 'auth.gnupg_keyring'):
             errors.append('Setting auth.gnupg_keyring is required.')
 
+        from irrd.updates.parser_state import RPSLSetAutnumAuthenticationMode
         for set_name, params in config.get('auth.set_creation', {}).items():
             if not isinstance(params.get('prefix_required', False), bool):
                 errors.append(f'Setting auth.set_creation.{set_name}.prefix_required must be a bool')
-            if params.get('autnum_authentication') and params['autnum_authentication'].lower() not in VALID_SET_AUTNUM_AUTHENTICATION:
-                errors.append(f'Setting auth.set_creation.{set_name}.autnum_authentication must be one of {VALID_SET_AUTNUM_AUTHENTICATION} if set')
+            valid_auth = [mode.value for mode in RPSLSetAutnumAuthenticationMode]
+            if params.get('autnum_authentication') and params['autnum_authentication'].lower() not in valid_auth:
+                errors.append(f'Setting auth.set_creation.{set_name}.autnum_authentication must be one of {valid_auth} if set')
 
         for name, access_list in config.get('access_lists', {}).items():
             for item in access_list:

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 PASSWORD_HASH_DUMMY_VALUE = 'DummyValue'
 SOURCE_NAME_RE = re.compile('^[A-Z][A-Z0-9-]*[A-Z0-9]$')
 RPKI_IRR_PSEUDO_SOURCE = 'RPKI'
+AUTH_SET_CREATION_COMMON_KEY = 'COMMON'
 
 
 LOGGING = {

--- a/irrd/conf/default_config.yaml
+++ b/irrd/conf/default_config.yaml
@@ -44,7 +44,7 @@ irrd:
             max_connections: 10
     auth:
         gnupg_keyring: null
-        authenticate_related_mntners: true
+        authenticate_parents_route_creation: true
     email:
         footer: ''
         notification_header: |

--- a/irrd/conf/default_config.yaml
+++ b/irrd/conf/default_config.yaml
@@ -45,6 +45,11 @@ irrd:
     auth:
         gnupg_keyring: null
         authenticate_parents_route_creation: true
+        set_creation:
+            COMMON:
+                prefix_required: true
+                autnum_authentication: opportunistic
+
     email:
         footer: ''
         notification_header: |

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -34,7 +34,7 @@ KNOWN_CONFIG_KEYS = DottedDict({
     },
     'auth': {
         'override_password': {},
-        'authenticate_related_mntners': {},
+        'authenticate_parents_route_creation': {},
         'gnupg_keyring': {},
         'set_creation': {
             rpsl_object_class: {'prefix_required': {}, 'autnum_authentication': {}}

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -1,3 +1,4 @@
+from irrd.conf import AUTH_SET_CREATION_COMMON_KEY
 from irrd.vendor.dotted.collection import DottedDict
 from irrd.rpsl.rpsl_objects import OBJECT_CLASS_MAPPING, RPSLSet
 
@@ -42,7 +43,7 @@ KNOWN_CONFIG_KEYS = DottedDict({
                 set_object.rpsl_object_class
                 for set_object in OBJECT_CLASS_MAPPING.values()
                 if issubclass(set_object, RPSLSet)
-            ] + ['DEFAULT']
+            ] + [AUTH_SET_CREATION_COMMON_KEY]
         },
     },
     'rpki': {

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -1,0 +1,91 @@
+from irrd.vendor.dotted.collection import DottedDict
+from irrd.rpsl.rpsl_objects import OBJECT_CLASS_MAPPING, RPSLSet
+
+# Note that sources are checked separately,
+# and 'access_lists' is always permitted
+KNOWN_CONFIG_KEYS = DottedDict({
+    'database_url': {},
+    'database_readonly': {},
+    'redis_url': {},
+    'piddir': {},
+    'user': {},
+    'group': {},
+    'server': {
+        'http': {
+            'interface': {},
+            'port': {},
+            'status_access_list': {},
+            'workers': {},
+            'forwarded_allowed_ips': {},
+        },
+        'whois': {
+            'interface': {},
+            'port': {},
+            'access_list': {},
+            'max_connections': {},
+        },
+    },
+    'email': {
+        'from': {},
+        'footer': {},
+        'smtp': {},
+        'recipient_override': {},
+        'notification_header': {},
+    },
+    'auth': {
+        'override_password': {},
+        'authenticate_related_mntners': {},
+        'gnupg_keyring': {},
+        'set_creation': {
+            rpsl_object_class: {'prefix_required': {}, 'autnum_authentication': {}}
+            for rpsl_object_class in [
+                set_object.rpsl_object_class
+                for set_object in OBJECT_CLASS_MAPPING.values()
+                if issubclass(set_object, RPSLSet)
+            ] + ['DEFAULT']
+        },
+    },
+    'rpki': {
+        'roa_source': {},
+        'roa_import_timer': {},
+        'slurm_source': {},
+        'pseudo_irr_remarks': {},
+        'notify_invalid_enabled': {},
+        'notify_invalid_subject': {},
+        'notify_invalid_header': {},
+    },
+    'scopefilter': {
+        'prefixes': {},
+        'asns': {},
+    },
+    'log': {
+        'logfile_path': {},
+        'level': {},
+        'logging_config_path': {},
+    },
+    'sources_default': {},
+    'compatibility': {
+        'inetnum_search_disabled': {},
+        'irrd42_migration_in_progress': {},
+        'ipv4_only_route_set_members': {},
+    }
+})
+
+KNOWN_SOURCES_KEYS = {
+    'authoritative',
+    'keep_journal',
+    'nrtm_host',
+    'nrtm_port',
+    'import_source',
+    'import_serial_source',
+    'import_timer',
+    'object_class_filter',
+    'export_destination',
+    'export_destination_unfiltered',
+    'export_timer',
+    'nrtm_access_list',
+    'nrtm_access_list_unfiltered',
+    'strict_import_keycert_objects',
+    'rpki_excluded',
+    'scopefilter_excluded',
+}

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -74,7 +74,7 @@ class TestConfiguration:
                 },
                 'auth': {
                     'gnupg_keyring': str(tmpdir),
-                    'authenticate_related_mntners': True,
+                    'authenticate_parents_route_creation': True,
                     'set_creation': {
                         'as-set': {
                             'prefix_required': True,

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -80,7 +80,7 @@ class TestConfiguration:
                             'prefix_required': True,
                             'autnum_authentication': 'opportunistic',
                         },
-                        'DEFAULT': {
+                        'COMMON': {
                             'prefix_required': True,
                             'autnum_authentication': 'required',
                         },

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -73,7 +73,18 @@ class TestConfiguration:
                     }
                 },
                 'auth': {
-                    'gnupg_keyring': str(tmpdir)
+                    'gnupg_keyring': str(tmpdir),
+                    'authenticate_related_mntners': True,
+                    'set_creation': {
+                        'as-set': {
+                            'prefix_required': True,
+                            'autnum_authentication': 'opportunistic',
+                        },
+                        'DEFAULT': {
+                            'prefix_required': True,
+                            'autnum_authentication': 'required',
+                        },
+                    },
                 },
                 'sources_default': ['TESTDB2', 'TESTDB'],
                 'sources': {
@@ -188,7 +199,7 @@ class TestConfiguration:
                     }
                 },
                 'auth': {
-                    'gnupg_keyring': str(tmpdir)
+                    'gnupg_keyring': str(tmpdir),
                 },
                 'rpki': {
                     'roa_source': 'https://example.com/roa.json',
@@ -239,6 +250,17 @@ class TestConfiguration:
                 'access_lists': {
                     'bad-list': {
                         '192.0.2.2.1'
+                    },
+                },
+                'auth': {
+                    'set_creation': {
+                        'as-set': {
+                            'prefix_required': 'not-a-bool',
+                            'autnum_authentication': 'unknown-value',
+                        },
+                        'not-a-real-set': {
+                            'prefix_required': True,
+                        },
                     },
                 },
                 'rpki': {
@@ -297,6 +319,9 @@ class TestConfiguration:
         assert 'Setting email.recipient_override must be an email address if set.' in str(ce.value)
         assert 'Settings user and group must both be defined, or neither.' in str(ce.value)
         assert 'Setting auth.gnupg_keyring is required.' in str(ce.value)
+        assert 'Unknown setting key: auth.set_creation.not-a-real-set.prefix_required' in str(ce.value)
+        assert 'Setting auth.set_creation.as-set.prefix_required must be a bool' in str(ce.value)
+        assert 'Setting auth.set_creation.as-set.autnum_authentication must be one of' in str(ce.value)
         assert 'Access lists doesnotexist, invalid-list referenced in settings, but not defined.' in str(ce.value)
         assert 'Setting server.http.status_access_list must be a string, if defined.' in str(ce.value)
         assert 'Invalid item in access list bad-list: IPv4 Address with more than 4 bytes.' in str(ce.value)

--- a/irrd/integration_tests/run.py
+++ b/irrd/integration_tests/run.py
@@ -765,6 +765,21 @@ class TestIntegration:
                 'auth': {
                     'gnupg_keyring': None,
                     'override_password': '$1$J6KycItM$MbPaBU6iFSGFV299Rk7Di0',
+                    'set_creation': {
+                        'filter-set': {
+                            'prefix_required': False,
+                        },
+                        'peering-set': {
+                            'prefix_required': False,
+                        },
+                        'route-set': {
+                            'prefix_required': False,
+                        },
+                        'rtr-set': {
+                            'prefix_required': False,
+                        },
+                    },
+
                 },
 
                 'email': {

--- a/irrd/rpsl/parser.py
+++ b/irrd/rpsl/parser.py
@@ -68,7 +68,7 @@ class RPSLObject(metaclass=RPSLObjectMeta):
     prefix_length: Optional[int] = None
     rpki_status: RPKIStatus = RPKIStatus.not_found
     scopefilter_status: ScopeFilterStatus = ScopeFilterStatus.in_scope
-    pk_first_segment: Optional[str] = None
+    pk_asn_segment: Optional[str] = None
     default_source: Optional[str] = None  # noqa: E704 (flake8 bug)
     # Whether this object has a relation to RPKI ROA data, and therefore RPKI
     # checks should be performed in certain scenarios. Enabled for route/route6.

--- a/irrd/rpsl/parser.py
+++ b/irrd/rpsl/parser.py
@@ -68,6 +68,7 @@ class RPSLObject(metaclass=RPSLObjectMeta):
     prefix_length: Optional[int] = None
     rpki_status: RPKIStatus = RPKIStatus.not_found
     scopefilter_status: ScopeFilterStatus = ScopeFilterStatus.in_scope
+    pk_first_segment: Optional[str] = None
     default_source: Optional[str] = None  # noqa: E704 (flake8 bug)
     # Whether this object has a relation to RPKI ROA data, and therefore RPKI
     # checks should be performed in certain scenarios. Enabled for route/route6.

--- a/irrd/rpsl/rpsl_objects.py
+++ b/irrd/rpsl/rpsl_objects.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from typing import Set, List, Optional, Union
 
-from irrd.conf import PASSWORD_HASH_DUMMY_VALUE, get_setting
+from irrd.conf import AUTH_SET_CREATION_COMMON_KEY, PASSWORD_HASH_DUMMY_VALUE, get_setting
 from irrd.utils.pgp import get_gpg_instance
 from .config import PASSWORD_HASHERS
 from .fields import (RPSLTextField, RPSLIPv4PrefixField, RPSLIPv4PrefixesField, RPSLIPv6PrefixField,
@@ -41,7 +41,7 @@ class RPSLSet(RPSLObject):
             self.pk_asn_segment = None
             if get_setting(f'auth.set_creation.{self.rpsl_object_class}.prefix_required') is False:
                 return True
-            if get_setting('auth.set_creation.DEFAULT.prefix_required') is False:
+            if get_setting(f'auth.set_creation.{AUTH_SET_CREATION_COMMON_KEY}.prefix_required') is False:
                 return True
             self.messages.error(f'{self.rpsl_object_class} names must be hierarchical and the first '
                                 f'component must be an AS number, e.g. "AS65537:{self.pk_asn_segment}": {str(ve)}')

--- a/irrd/rpsl/rpsl_objects.py
+++ b/irrd/rpsl/rpsl_objects.py
@@ -31,6 +31,23 @@ def rpsl_object_from_text(text, strict_validation=True, default_source: Optional
     return klass(from_text=text, strict_validation=strict_validation, default_source=default_source)
 
 
+class RPSLSet(RPSLObject):
+    def clean_for_create(self) -> bool:
+        if get_setting(f'auth.set_creation.{self.rpsl_object_class}.prefix_required') is False:
+            return True
+        if get_setting('auth.set_creation.DEFAULT.prefix_required') is False:
+            return True
+
+        first_segment = self.pk().split(':')[0]
+        try:
+            parse_as_number(first_segment)
+            return True
+        except ValidationError as ve:
+            self.messages.error(f'{self.rpsl_object_class} names must be hierarchical and the first '
+                                f'component must be an AS number, e.g. "AS65537:{first_segment}": {str(ve)}')
+        return False
+
+
 class RPSLAsBlock(RPSLObject):
     fields = OrderedDict([
         ('as-block', RPSLASBlockField(primary_key=True, lookup_key=True)),
@@ -45,7 +62,7 @@ class RPSLAsBlock(RPSLObject):
     ])
 
 
-class RPSLAsSet(RPSLObject):
+class RPSLAsSet(RPSLSet):
     fields = OrderedDict([
         ('as-set', RPSLSetNameField(primary_key=True, lookup_key=True, prefix='AS')),
         ('descr', RPSLTextField(multiple=True, optional=True)),
@@ -59,19 +76,6 @@ class RPSLAsSet(RPSLObject):
         ('changed', RPSLChangedField(optional=True, multiple=True)),
         ('source', RPSLGenericNameField()),
     ])
-
-    def clean_for_create(self) -> bool:
-        if get_setting('compatibility.permit_non_hierarchical_as_set_name'):
-            return True
-
-        first_segment = self.pk().split(':')[0]
-        try:
-            parse_as_number(first_segment)
-            return True
-        except ValidationError as ve:
-            self.messages.error('AS set names must be hierarchical and the first component must '
-                                f'be an AS number, e.g. "AS65537:AS-EXAMPLE": {str(ve)}')
-        return False
 
 
 class RPSLAutNum(RPSLObject):
@@ -117,7 +121,7 @@ class RPSLDomain(RPSLObject):
     ])
 
 
-class RPSLFilterSet(RPSLObject):
+class RPSLFilterSet(RPSLSet):
     fields = OrderedDict([
         ('filter-set', RPSLSetNameField(primary_key=True, lookup_key=True, prefix='FLTR')),
         ('descr', RPSLTextField(multiple=True, optional=True)),
@@ -355,7 +359,7 @@ class RPSLMntner(RPSLObject):
         return [auth for auth in lines if ' ' not in auth]
 
 
-class RPSLPeeringSet(RPSLObject):
+class RPSLPeeringSet(RPSLSet):
     fields = OrderedDict([
         ('peering-set', RPSLSetNameField(primary_key=True, lookup_key=True, prefix='PRNG')),
         ('descr', RPSLTextField(multiple=True, optional=True)),
@@ -432,7 +436,7 @@ class RPSLRoute(RPSLObject):
     ])
 
 
-class RPSLRouteSet(RPSLObject):
+class RPSLRouteSet(RPSLSet):
     fields = OrderedDict([
         ('route-set', RPSLSetNameField(primary_key=True, lookup_key=True, prefix='RS')),
         ('members', RPSLRouteSetMembersField(ip_version=4, lookup_key=True, optional=True, multiple=True)),
@@ -475,7 +479,7 @@ class RPSLRoute6(RPSLObject):
     ])
 
 
-class RPSLRtrSet(RPSLObject):
+class RPSLRtrSet(RPSLSet):
     fields = OrderedDict([
         ('rtr-set', RPSLSetNameField(primary_key=True, lookup_key=True, prefix='RTRS')),
         ('descr', RPSLTextField(multiple=True, optional=True)),

--- a/irrd/rpsl/rpsl_objects.py
+++ b/irrd/rpsl/rpsl_objects.py
@@ -33,19 +33,18 @@ def rpsl_object_from_text(text, strict_validation=True, default_source: Optional
 
 class RPSLSet(RPSLObject):
     def clean_for_create(self) -> bool:
-        # TODO: validate this attribute in the tests
-        self.pk_first_segment = self.pk().split(':')[0]
+        self.pk_asn_segment = self.pk().split(':')[0]
         try:
-            parse_as_number(self.pk_first_segment)
+            parse_as_number(self.pk_asn_segment)
             return True
         except ValidationError as ve:
-            self.pk_first_segment = None
+            self.pk_asn_segment = None
             if get_setting(f'auth.set_creation.{self.rpsl_object_class}.prefix_required') is False:
                 return True
             if get_setting('auth.set_creation.DEFAULT.prefix_required') is False:
                 return True
             self.messages.error(f'{self.rpsl_object_class} names must be hierarchical and the first '
-                                f'component must be an AS number, e.g. "AS65537:{self.pk_first_segment}": {str(ve)}')
+                                f'component must be an AS number, e.g. "AS65537:{self.pk_asn_segment}": {str(ve)}')
 
             return False
 

--- a/irrd/rpsl/tests/test_rpsl_objects.py
+++ b/irrd/rpsl/tests/test_rpsl_objects.py
@@ -154,9 +154,13 @@ class TestRPSLAsSet:
         assert obj.__class__ == RPSLAsSet
         assert not obj.messages.errors()
         assert not obj.clean_for_create()
-        assert 'AS set names must be hierarchical and the first ' in obj.messages.errors()[0]
+        assert 'as-set names must be hierarchical and the first ' in obj.messages.errors()[0]
 
-        config_override({'compatibility': {'permit_non_hierarchical_as_set_name': True}})
+        config_override({'auth': {'set_creation': {'as-set': {'prefix_required': False}}}})
+        obj = rpsl_object_from_text(rpsl_text)
+        assert obj.clean_for_create()
+
+        config_override({'auth': {'set_creation': {'DEFAULT': {'prefix_required': False}}}})
         obj = rpsl_object_from_text(rpsl_text)
         assert obj.clean_for_create()
 

--- a/irrd/rpsl/tests/test_rpsl_objects.py
+++ b/irrd/rpsl/tests/test_rpsl_objects.py
@@ -5,7 +5,7 @@ from IPy import IP
 from pytest import raises
 from pytz import timezone
 
-from irrd.conf import PASSWORD_HASH_DUMMY_VALUE
+from irrd.conf import PASSWORD_HASH_DUMMY_VALUE, AUTH_SET_CREATION_COMMON_KEY
 from irrd.utils.rpsl_samples import (object_sample_mapping, SAMPLE_MALFORMED_EMPTY_LINE,
                                      SAMPLE_MALFORMED_ATTRIBUTE_NAME,
                                      SAMPLE_UNKNOWN_CLASS, SAMPLE_MISSING_MANDATORY_ATTRIBUTE,
@@ -163,7 +163,9 @@ class TestRPSLAsSet:
         assert obj.clean_for_create()
         assert not obj.pk_asn_segment
 
-        config_override({'auth': {'set_creation': {'DEFAULT': {'prefix_required': False}}}})
+        config_override({'auth': {'set_creation': {
+            AUTH_SET_CREATION_COMMON_KEY: {'prefix_required': False}
+        }}})
         obj = rpsl_object_from_text(rpsl_text)
         assert obj.clean_for_create()
         assert not obj.pk_asn_segment

--- a/irrd/rpsl/tests/test_rpsl_objects.py
+++ b/irrd/rpsl/tests/test_rpsl_objects.py
@@ -142,6 +142,7 @@ class TestRPSLAsSet:
         ]
         assert obj.references_strong_inbound() == set()
         assert obj.source() == 'TEST'
+        assert obj.pk_asn_segment == 'AS65537'
 
         assert obj.parsed_data['members'] == ['AS65538', 'AS65539', 'AS65537', 'AS-OTHERSET']
         # Field parsing will cause our object to look slightly different than the original, hence the replace()
@@ -154,15 +155,18 @@ class TestRPSLAsSet:
         assert obj.__class__ == RPSLAsSet
         assert not obj.messages.errors()
         assert not obj.clean_for_create()
+        assert not obj.pk_asn_segment
         assert 'as-set names must be hierarchical and the first ' in obj.messages.errors()[0]
 
         config_override({'auth': {'set_creation': {'as-set': {'prefix_required': False}}}})
         obj = rpsl_object_from_text(rpsl_text)
         assert obj.clean_for_create()
+        assert not obj.pk_asn_segment
 
         config_override({'auth': {'set_creation': {'DEFAULT': {'prefix_required': False}}}})
         obj = rpsl_object_from_text(rpsl_text)
         assert obj.clean_for_create()
+        assert not obj.pk_asn_segment
 
 
 class TestRPSLAutNum:

--- a/irrd/updates/parser_state.py
+++ b/irrd/updates/parser_state.py
@@ -1,5 +1,7 @@
 from enum import unique, Enum
 
+from irrd.conf import get_setting
+
 
 @unique
 class UpdateRequestType(Enum):
@@ -19,3 +21,19 @@ class UpdateRequestStatus(Enum):
     ERROR_ROA = 'error: conflict with existing ROA'
     ERROR_SCOPEFILTER = 'error: not in scope'
     ERROR_NON_AUTHORITIVE = 'error: attempt to update object in non-authoritive database'
+
+
+@unique
+class RPSLSetAutnumAuthenticationMode(Enum):
+    DISABLED = 'disabled'
+    OPPORTUNISTIC = 'opportunistic'
+    REQUIRED = 'required'
+
+    @staticmethod
+    def for_set_name(set_name: str):
+        setting = get_setting(f'auth.set_creation.{set_name}.autnum_authentication')
+        if not setting:
+            setting = get_setting('auth.set_creation.DEFAULT.autnum_authentication')
+        if not setting:
+            return RPSLSetAutnumAuthenticationMode.DISABLED
+        return getattr(RPSLSetAutnumAuthenticationMode, setting.upper())

--- a/irrd/updates/parser_state.py
+++ b/irrd/updates/parser_state.py
@@ -34,6 +34,4 @@ class RPSLSetAutnumAuthenticationMode(Enum):
         setting = get_setting(f'auth.set_creation.{set_name}.autnum_authentication')
         if not setting:
             setting = get_setting(f'auth.set_creation.{AUTH_SET_CREATION_COMMON_KEY}.autnum_authentication')
-        if not setting:
-            return RPSLSetAutnumAuthenticationMode.DISABLED
         return getattr(RPSLSetAutnumAuthenticationMode, setting.upper())

--- a/irrd/updates/parser_state.py
+++ b/irrd/updates/parser_state.py
@@ -1,6 +1,6 @@
 from enum import unique, Enum
 
-from irrd.conf import get_setting
+from irrd.conf import get_setting, AUTH_SET_CREATION_COMMON_KEY
 
 
 @unique
@@ -33,7 +33,7 @@ class RPSLSetAutnumAuthenticationMode(Enum):
     def for_set_name(set_name: str):
         setting = get_setting(f'auth.set_creation.{set_name}.autnum_authentication')
         if not setting:
-            setting = get_setting('auth.set_creation.DEFAULT.autnum_authentication')
+            setting = get_setting(f'auth.set_creation.{AUTH_SET_CREATION_COMMON_KEY}.autnum_authentication')
         if not setting:
             return RPSLSetAutnumAuthenticationMode.DISABLED
         return getattr(RPSLSetAutnumAuthenticationMode, setting.upper())

--- a/irrd/updates/tests/test_parser.py
+++ b/irrd/updates/tests/test_parser.py
@@ -700,7 +700,7 @@ class TestSingleChangeRequestHandling:
         assert 'Ignoring override password, auth.override_password not set.' in caplog.text
 
     def test_check_valid_related_mntners_disabled(self, prepare_mocks, config_override):
-        config_override({'auth': {'authenticate_related_mntners': False}})
+        config_override({'auth': {'authenticate_parents_route_creation': False}})
         mock_dq, mock_dh = prepare_mocks
 
         query_answers = [

--- a/irrd/updates/tests/test_parser.py
+++ b/irrd/updates/tests/test_parser.py
@@ -133,7 +133,7 @@ class TestSingleChangeRequestHandling:
         assert not result.validate()
         assert result.status == UpdateRequestStatus.ERROR_PARSING
         assert len(result.error_messages) == 1
-        assert 'AS set names must be hierarchical and the first' in result.error_messages[0]
+        assert 'as-set names must be hierarchical and the first' in result.error_messages[0]
 
         # Test again with an UPDATE (which then fails on auth to stop)
         mock_dh.execute_query = lambda query: [{'object_text': SAMPLE_AS_SET}]

--- a/irrd/updates/tests/test_validators.py
+++ b/irrd/updates/tests/test_validators.py
@@ -287,7 +287,7 @@ class TestAuthValidatorRelatedRouteObjects:
             'RELATED-MNT - from parent inetnum 192.0.2.0-192.0.2.255'
         }
 
-        config_override({'auth': {'authenticate_related_mntners': False}})
+        config_override({'auth': {'authenticate_parents_route_creation': False}})
         result = validator.process_auth(route, None)
         assert result.is_valid()
         config_override({})

--- a/irrd/updates/tests/test_validators.py
+++ b/irrd/updates/tests/test_validators.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 from pytest import raises
 
+from irrd.conf import AUTH_SET_CREATION_COMMON_KEY
 from irrd.rpsl.rpsl_objects import rpsl_object_from_text
 from irrd.utils.rpsl_samples import (SAMPLE_AS_SET, SAMPLE_FILTER_SET, SAMPLE_MNTNER, SAMPLE_MNTNER_CRYPT,
                                      SAMPLE_MNTNER_MD5, SAMPLE_PERSON,
@@ -511,7 +512,9 @@ class TestAuthValidatorRelatedAutNumObjects:
         assert result.is_valid()
 
     def test_as_set_autnum_opportunistic_does_not_exist(self, prepare_mocks, config_override):
-        config_override({'auth': {'set_creation': {'DEFAULT': {'autnum_authentication': 'opportunistic'}}}})
+        config_override({'auth': {'set_creation': {
+            AUTH_SET_CREATION_COMMON_KEY: {'autnum_authentication': 'opportunistic'}
+        }}})
         validator, mock_dq, mock_dh = prepare_mocks
         as_set = rpsl_object_from_text(SAMPLE_AS_SET)
         assert as_set.clean_for_create()  # fill pk_first_segment
@@ -536,7 +539,9 @@ class TestAuthValidatorRelatedAutNumObjects:
         ]
 
     def test_as_set_autnum_required_does_not_exist(self, prepare_mocks, config_override):
-        config_override({'auth': {'set_creation': {'DEFAULT': {'autnum_authentication': 'required'}}}})
+        config_override({'auth': {'set_creation': {
+            AUTH_SET_CREATION_COMMON_KEY: {'autnum_authentication': 'required'}
+        }}})
         validator, mock_dq, mock_dh = prepare_mocks
         as_set = rpsl_object_from_text(SAMPLE_AS_SET)
         assert as_set.clean_for_create()  # fill pk_first_segment
@@ -554,10 +559,12 @@ class TestAuthValidatorRelatedAutNumObjects:
         }
 
     def test_filter_set_autnum_required_no_prefix(self, prepare_mocks, config_override):
-        config_override({'auth': {'set_creation': {'DEFAULT': {
-            'autnum_authentication': 'required',
-            'prefix_required': False,
-        }}}})
+        config_override({'auth': {'set_creation': {
+            AUTH_SET_CREATION_COMMON_KEY: {
+                'autnum_authentication': 'required',
+                'prefix_required': False,
+            }
+        }}})
         validator, mock_dq, mock_dh = prepare_mocks
         filter_set = rpsl_object_from_text(SAMPLE_FILTER_SET)
         assert filter_set.clean_for_create()

--- a/irrd/updates/tests/test_validators.py
+++ b/irrd/updates/tests/test_validators.py
@@ -138,6 +138,7 @@ class TestAuthValidator:
             ['sources', (['TEST'],), {}],
             ['object_classes', (['mntner'],), {}],
             ['rpsl_pks', ({'TEST-MNT', 'TEST-NEW-MNT'},), {}],
+
             ['sources', (['TEST'],), {}],
             ['object_classes', (['mntner'],), {}],
             ['rpsl_pks', ({'TEST-OLD-MNT'},), {}],  # TEST-MNT is cached
@@ -266,8 +267,8 @@ class TestAuthValidatorRelatedRouteObjects:
             ['sources', (['TEST'],), {}],
             ['object_classes', (['mntner'],), {}],
             ['rpsl_pks', ({'TEST-MNT'},), {}],
-            ['sources', (['TEST'],), {}],
 
+            ['sources', (['TEST'],), {}],
             ['object_classes', (['inetnum'],), {}],
             ['first_only', (), {}],
             ['ip_exact', ('192.0.2.0/24',), {}],
@@ -367,8 +368,8 @@ class TestAuthValidatorRelatedRouteObjects:
             ['sources', (['TEST'],), {}],
             ['object_classes', (['mntner'],), {}],
             ['rpsl_pks', ({'TEST-MNT'},), {}],
-            ['sources', (['TEST'],), {}],
 
+            ['sources', (['TEST'],), {}],
             ['object_classes', (['inetnum'],), {}],
             ['first_only', (), {}],
             ['ip_exact', ('192.0.2.0/24',), {}],
@@ -412,13 +413,12 @@ class TestAuthValidatorRelatedRouteObjects:
         result = validator.process_auth(route, None)
         assert result.is_valid()
 
-        # TODO: this grouping is confusing re sources
         assert flatten_mock_calls(mock_dq, flatten_objects=True) == [
             ['sources', (['TEST'],), {}],
             ['object_classes', (['mntner'],), {}],
             ['rpsl_pks', ({'TEST-MNT'},), {}],
-            ['sources', (['TEST'],), {}],
 
+            ['sources', (['TEST'],), {}],
             ['object_classes', (['inet6num'],), {}],
             ['first_only', (), {}],
             ['ip_exact', ('2001:db8::/48',), {}],
@@ -440,7 +440,7 @@ class TestAuthValidatorRelatedAutNumObjects:
         config_override({'auth': {'set_creation': {'as-set': {'autnum_authentication': 'disabled'}}}})
         validator, mock_dq, mock_dh = prepare_mocks
         as_set = rpsl_object_from_text(SAMPLE_AS_SET)
-        assert as_set.clean_for_create()  # fill pk_first_segment
+        assert as_set.clean_for_create()  # fill pk_asn_segment
         mock_dh.execute_query = lambda q: [
             {'object_text': SAMPLE_MNTNER.replace('MD5', '')},  # mntner for object
         ]
@@ -458,7 +458,7 @@ class TestAuthValidatorRelatedAutNumObjects:
         config_override({'auth': {'set_creation': {'as-set': {'autnum_authentication': 'opportunistic'}}}})
         validator, mock_dq, mock_dh = prepare_mocks
         as_set = rpsl_object_from_text(SAMPLE_AS_SET)
-        assert as_set.clean_for_create()  # fill pk_first_segment
+        assert as_set.clean_for_create()  # fill pk_asn_segment
         query_results = itertools.cycle([
             [{'object_text': SAMPLE_MNTNER.replace('MD5', '')}],  # mntner for object
             [{

--- a/irrd/updates/tests/test_validators.py
+++ b/irrd/updates/tests/test_validators.py
@@ -455,8 +455,7 @@ class TestAuthValidatorRelatedAutNumObjects:
             ['rpsl_pks', ({'TEST-MNT'},), {}],
         ]
 
-    def test_as_set_autnum_opportunistic_exists(self, prepare_mocks, config_override):
-        config_override({'auth': {'set_creation': {'as-set': {'autnum_authentication': 'opportunistic'}}}})
+    def test_as_set_autnum_opportunistic_exists_default(self, prepare_mocks, config_override):
         validator, mock_dq, mock_dh = prepare_mocks
         as_set = rpsl_object_from_text(SAMPLE_AS_SET)
         assert as_set.clean_for_create()  # fill pk_asn_segment
@@ -503,11 +502,6 @@ class TestAuthValidatorRelatedAutNumObjects:
         assert result.is_valid()
 
         config_override({'auth': {'set_creation': {'as-set': {'autnum_authentication': 'disabled'}}}})
-        result = validator.process_auth(as_set, None)
-        assert result.is_valid()
-
-        # Default is disabled
-        config_override({})
         result = validator.process_auth(as_set, None)
         assert result.is_valid()
 

--- a/irrd/updates/validators.py
+++ b/irrd/updates/validators.py
@@ -354,12 +354,12 @@ class AuthValidator:
         """
         @functools.lru_cache(maxsize=50)
         def _find_in_db():
-            query = _init_related_object_query('aut-num', rpsl_obj_new).rpsl_pk(rpsl_obj_new.pk_first_segment)
+            query = _init_related_object_query('aut-num', rpsl_obj_new).rpsl_pk(rpsl_obj_new.pk_asn_segment)
             aut_nums = list(self.database_handler.execute_query(query))
             if aut_nums:
                 return aut_nums[0]
 
-        if not rpsl_obj_new.pk_first_segment:
+        if not rpsl_obj_new.pk_asn_segment:
             return None
 
         mode = RPSLSetAutnumAuthenticationMode.for_set_name(rpsl_obj_new.rpsl_object_class)
@@ -371,7 +371,7 @@ class AuthValidator:
             return aut_num
         elif mode == RPSLSetAutnumAuthenticationMode.REQUIRED:
             result.error_messages.add(
-                f'Creating this object requires an aut-num for {rpsl_obj_new.pk_first_segment} to exist.'
+                f'Creating this object requires an aut-num for {rpsl_obj_new.pk_asn_segment} to exist.'
             )
         return None
 

--- a/irrd/updates/validators.py
+++ b/irrd/updates/validators.py
@@ -212,17 +212,16 @@ class AuthValidator:
             result.mntners_notify = mntner_objs_current
         else:
             result.mntners_notify = mntner_objs_new
-            if get_setting('auth.authenticate_related_mntners'):
-                mntners_related = self._find_related_mntners(rpsl_obj_new, result)
-                if mntners_related:
-                    related_object_class, related_pk, related_mntner_list = mntners_related
-                    logger.debug(f'Checking auth for related object {related_object_class} / '
-                                 f'{related_pk} with mntners {related_mntner_list}')
-                    valid, mntner_objs_related = self._check_mntners(related_mntner_list, source)
-                    if not valid:
-                        self._generate_failure_message(result, related_mntner_list, rpsl_obj_new,
-                                                       related_object_class, related_pk)
-                        result.mntners_notify = mntner_objs_related
+            mntners_related = self._find_related_mntners(rpsl_obj_new, result)
+            if mntners_related:
+                related_object_class, related_pk, related_mntner_list = mntners_related
+                logger.debug(f'Checking auth for related object {related_object_class} / '
+                             f'{related_pk} with mntners {related_mntner_list}')
+                valid, mntner_objs_related = self._check_mntners(related_mntner_list, source)
+                if not valid:
+                    self._generate_failure_message(result, related_mntner_list, rpsl_obj_new,
+                                                   related_object_class, related_pk)
+                    result.mntners_notify = mntner_objs_related
 
         if isinstance(rpsl_obj_new, RPSLMntner):
             if not rpsl_obj_current:
@@ -322,6 +321,9 @@ class AuthValidator:
         Find the related inetnum/route object to rpsl_obj_new, which must be a route(6).
         Returns a dict as returned by the database handler.
         """
+        if not get_setting('auth.authenticate_parents_route_creation'):
+            return None
+
         inetnum_class = {
             'route': 'inetnum',
             'route6': 'inet6num',

--- a/irrd/updates/validators.py
+++ b/irrd/updates/validators.py
@@ -299,7 +299,7 @@ class AuthValidator:
         - object class of the related object
         - PK of the related object
         - List of maintainers for the related object (at least one must pass)
-        Returns None of no related objects were found that should be authenticated.
+        Returns None if no related objects were found that should be authenticated.
 
         Custom error messages may be added directly to the passed ValidatorResult.
         """

--- a/irrd/updates/validators.py
+++ b/irrd/updates/validators.py
@@ -8,10 +8,10 @@ from passlib.hash import md5_crypt
 
 from irrd.conf import get_setting
 from irrd.rpsl.parser import RPSLObject
-from irrd.rpsl.rpsl_objects import RPSLMntner, rpsl_object_from_text
+from irrd.rpsl.rpsl_objects import RPSLMntner, rpsl_object_from_text, RPSLSet
 from irrd.storage.database_handler import DatabaseHandler
 from irrd.storage.queries import RPSLDatabaseQuery
-from .parser_state import UpdateRequestType
+from .parser_state import RPSLSetAutnumAuthenticationMode, UpdateRequestType
 
 if TYPE_CHECKING:  # pragma: no cover
     # http://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
@@ -43,6 +43,7 @@ class ReferenceValidator:
     in the same update message. To handle this, the validator can be preloaded
     with objects that should be considered valid.
     """
+
     def __init__(self, database_handler: DatabaseHandler) -> None:
         self.database_handler = database_handler
         self._cache: Set[Tuple[str, str, str]] = set()
@@ -212,7 +213,7 @@ class AuthValidator:
         else:
             result.mntners_notify = mntner_objs_new
             if get_setting('auth.authenticate_related_mntners'):
-                mntners_related = self._find_related_mntners(rpsl_obj_new)
+                mntners_related = self._find_related_mntners(rpsl_obj_new, result)
                 if mntners_related:
                     related_object_class, related_pk, related_mntner_list = mntners_related
                     logger.debug(f'Checking auth for related object {related_object_class} / '
@@ -289,8 +290,7 @@ class AuthValidator:
             msg += f' - from parent {related_object_class} {related_pk}'
         result.error_messages.add(msg)
 
-    @functools.lru_cache(maxsize=50)
-    def _find_related_mntners(self, rpsl_obj_new: RPSLObject) -> Optional[Tuple[str, str, List[str]]]:
+    def _find_related_mntners(self, rpsl_obj_new: RPSLObject, result: ValidatorResult) -> Optional[Tuple[str, str, List[str]]]:
         """
         Find the maintainers of the related object to rpsl_obj_new, if any.
         This is used to authorise creating objects - authentication may be
@@ -301,10 +301,14 @@ class AuthValidator:
         - PK of the related object
         - List of maintainers for the related object (at least one must pass)
         Returns None of no related objects were found that should be authenticated.
+
+        Custom error messages may be added directly to the passed ValidatorResult.
         """
         related_object = None
         if rpsl_obj_new.rpsl_object_class in ['route', 'route6']:
             related_object = self._find_related_object_route(rpsl_obj_new)
+        if issubclass(rpsl_obj_new.__class__, RPSLSet):
+            related_object = self._find_related_object_set(rpsl_obj_new, result)
 
         if related_object:
             mntners = related_object.get('parsed_data', {}).get('mnt-by', [])
@@ -312,6 +316,7 @@ class AuthValidator:
 
         return None
 
+    @functools.lru_cache(maxsize=50)
     def _find_related_object_route(self, rpsl_obj_new: RPSLObject):
         """
         Find the related inetnum/route object to rpsl_obj_new, which must be a route(6).
@@ -339,6 +344,35 @@ class AuthValidator:
         if routes:
             return routes[0]
 
+        return None
+
+    def _find_related_object_set(self, rpsl_obj_new: RPSLObject, result: ValidatorResult):
+        """
+        Find the related aut-num object to rpsl_obj_new, which must be a set object,
+        depending on settings.
+        Returns a dict as returned by the database handler.
+        """
+        @functools.lru_cache(maxsize=50)
+        def _find_in_db():
+            query = _init_related_object_query('aut-num', rpsl_obj_new).rpsl_pk(rpsl_obj_new.pk_first_segment)
+            aut_nums = list(self.database_handler.execute_query(query))
+            if aut_nums:
+                return aut_nums[0]
+
+        if not rpsl_obj_new.pk_first_segment:
+            return None
+
+        mode = RPSLSetAutnumAuthenticationMode.for_set_name(rpsl_obj_new.rpsl_object_class)
+        if mode == RPSLSetAutnumAuthenticationMode.DISABLED:
+            return None
+
+        aut_num = _find_in_db()
+        if aut_num:
+            return aut_num
+        elif mode == RPSLSetAutnumAuthenticationMode.REQUIRED:
+            result.error_messages.add(
+                f'Creating this object requires an aut-num for {rpsl_obj_new.pk_first_segment} to exist.'
+            )
         return None
 
 


### PR DESCRIPTION
docs:
https://irrd.readthedocs.io/en/extended-set-575-2/admins/configuration/#authentication-and-validation
https://irrd.readthedocs.io/en/extended-set-575-2/users/database-changes/#related-maintainers-in-set-objects

- [x] fix inline todo's
- [x] authenticate_related_mntners setting may now be confusing
- [x] write docs
- [x] decide on appropriate defaults for new auth.set_creation setting
- [x] Look into upgrade path: when people migrate with 4.1 settings, should we still accept those? Concerns one rename and one removed setting. Keep an eye on confusing/conflicting settings and defaults.
- [x] Write release notes for the upgrade path.
- [x] review/refactor all code/docs
- [x] deploy and verify working on test instance
- [x] cleanup test_validators.py
- [x] check integration test
