### PR TITLE
Improve CI performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
 jobs:
   cpython-3.7:
     &test-template
+    resource_class: large
     docker:
       - image: cimg/python:3.7
         environment:
@@ -160,8 +161,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
 
       - image: cimg/redis:5.0
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
-    resource_class: large
 
   pypy-3.9:
     <<: *test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,15 @@
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
-version: 2
+version: 2.1
 workflows:
-  version: 2
   test:
     jobs:
-      - cpython-3.7
-      - cpython-3.10
-      - pypy-3.9
-      - pypy-3.7
+      - cpython-3-7
+      - cpython-3-10
+      - pypy-3-9
+      - pypy-3-7
 jobs:
-  cpython-3.7:
+  cpython-3-7:
     &test-template
     resource_class: large
     docker:
@@ -139,7 +138,7 @@ jobs:
       - store_artifacts:
           path: /tmp/pytest-of-circleci/
 
-  cpython-3.10:
+  cpython-3-10:
     <<: *test-template
     docker:
       - image: cimg/python:3.10
@@ -162,7 +161,7 @@ jobs:
 
       - image: cimg/redis:5.0
 
-  pypy-3.9:
+  pypy-3-9:
     <<: *test-template
     docker:
       - image: pypy:3.9
@@ -174,7 +173,7 @@ jobs:
           IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
           IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
           PYTHON_INTERPRETER: pypy3
-          SUDO: ''
+          SUDO: sudo
           ENCHANT_PACKAGE: python3-enchant
 
       - image: cimg/postgres:10.17
@@ -185,7 +184,7 @@ jobs:
 
       - image: cimg/redis:5.0
 
-  pypy-3.7:
+  pypy-3-7:
     <<: *test-template
     docker:
       - image: pypy:3.7
@@ -197,7 +196,7 @@ jobs:
           IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
           IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
           PYTHON_INTERPRETER: pypy3
-          SUDO: ''
+          SUDO: sudo
           ENCHANT_PACKAGE: python3-enchant
 
       - image: cimg/postgres:10.17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 version: 2.1
 workflows:
-  test-all:
+  test:
     jobs:
       - unit_tests:
           name: unit-tests-cpython-3-7
@@ -20,6 +20,29 @@ workflows:
           docker_image: pypy:3.7
           python_interpreter: pypy3
           sudo_command: ''
+      - integration_tests:
+          name: integration-tests-cpython-3-7
+          docker_image: cimg/python:3.7
+      - integration_tests:
+          name: integration-tests-cpython-3-10
+          docker_image: cimg/python:3.10
+      - integration_tests:
+          name: integration-tests-pypy-3-7
+          python_interpreter: pypy3
+          docker_image: pypy:3.7
+          sudo_command: ''
+      - integration_tests:
+          name: integration-tests-pypy-3.9
+          docker_image: pypy:3.7
+          python_interpreter: pypy3
+          sudo_command: ''
+      - lint:
+          name: lint-cpython-3-10
+          docker_image: cimg/python:3.10
+      - build_docs:
+          name: build-docs-cpython-3-10
+          docker_image: cimg/python:3.10
+
 
 jobs:
   unit_tests:
@@ -38,9 +61,107 @@ jobs:
       - image: << parameters.docker_image >>
         environment:
           IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
+          IRRD_REDIS_URL: 'redis://localhost'
+          PYTHON_INTERPRETER: << parameters.python_interpreter >>
+          SUDO: << parameters.sudo_command >>
+
+      - image: cimg/postgres:10.17
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+
+      - image: cimg/redis:5.0
+
+    working_directory: /mnt/ramdisk
+
+    steps:
+      - checkout
+
+      - run:
+          name: apt update
+          command: |
+            set +e
+            $SUDO apt update
+            echo
+
+      - run:
+          name: Installing psql client and enchant
+          command: $SUDO apt -y install postgresql-client netcat python3-enchant
+
+      - run:
+          name: Install rust
+          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - restore_cache:
+          keys:
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+              "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
+
+      - run:
+          name: install latest pip
+          command: |
+            $PYTHON_INTERPRETER -m venv venv
+            . venv/bin/activate
+            pip install -U pip
+
+      - run:
+          name: install dependencies
+          command: |
+            PATH=$PATH:/root/.cargo/bin/
+            $PYTHON_INTERPRETER -m venv venv
+            . venv/bin/activate
+            pip install -Ur requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+            "requirements.txt" }}
+
+      - run:
+          name: Waiting for PostgreSQL to be ready
+          command: |
+            for i in `seq 1 10`;
+            do
+              nc -z localhost 5432 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for PostgreSQL && exit 1
+
+      - run:
+          name: run regular tests
+          command: |
+            . venv/bin/activate
+            py.test -s -vvvv --cov=irrd irrd --junitxml=test-reports/junit.xml --cov-fail-under=100 --cov-report term-missing:skip-covered
+
+      - store_test_results:
+          path: test-reports
+
+      - store_artifacts:
+          path: /tmp/pytest-of-circleci/
+
+
+  integration_tests:
+    parameters:
+      docker_image:
+        type: string
+      python_interpreter:
+        type: string
+        default: python3
+      sudo_command:
+        type: string
+        default: sudo
+
+    resource_class: large
+    docker:
+      - image: << parameters.docker_image >>
+        environment:
           IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
           IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-          IRRD_REDIS_URL: 'redis://localhost'
           IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
           IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
           PYTHON_INTERPRETER: << parameters.python_interpreter >>
@@ -124,22 +245,76 @@ jobs:
             circle_test_integration_2;"
 
       - run:
-          name: run regular tests
-          command: |
-            . venv/bin/activate
-            py.test -s -vvvv --cov=irrd irrd --junitxml=test-reports/junit.xml --cov-fail-under=100 --cov-report term-missing:skip-covered
-
-      - run:
           name: run integration tests
           command: |
             . venv/bin/activate
             py.test irrd/integration_tests/run.py -s
 
+      - store_artifacts:
+          path: /tmp/pytest-of-circleci/
+
+
+  lint:
+    parameters:
+      docker_image:
+        type: string
+      python_interpreter:
+        type: string
+        default: python3
+      sudo_command:
+        type: string
+        default: sudo
+
+    resource_class: large
+    docker:
+      - image: << parameters.docker_image >>
+        environment:
+          PYTHON_INTERPRETER: << parameters.python_interpreter >>
+          SUDO: << parameters.sudo_command >>
+
+    working_directory: /mnt/ramdisk
+
+    steps:
+      - checkout
+
       - run:
-          name: build docs
+          name: apt update
           command: |
+            set +e
+            $SUDO apt update
+            echo
+
+      - run:
+          name: Install rust
+          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - restore_cache:
+          keys:
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+              "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
+
+      - run:
+          name: install latest pip
+          command: |
+            $PYTHON_INTERPRETER -m venv venv
             . venv/bin/activate
-            sphinx-build -nW -b spelling docs/ docs/build
+            pip install -U pip
+
+      - run:
+          name: install dependencies
+          command: |
+            PATH=$PATH:/root/.cargo/bin/
+            $PYTHON_INTERPRETER -m venv venv
+            . venv/bin/activate
+            pip install -Ur requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+            "requirements.txt" }}
 
       - run:
           name: run flake8
@@ -153,77 +328,71 @@ jobs:
             . venv/bin/activate
             if command -v COMMAND &> /dev/null; then mypy irrd --ignore-missing-imports; fi
 
-      - store_test_results:
-          path: test-reports
 
-      - store_artifacts:
-          path: /tmp/pytest-of-circleci/
-#
-#  cpython-3-10:
-#    <<: *test-template
-#    docker:
-#      - image: cimg/python:3.10
-#        environment:
-#          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-#          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-#          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-#          IRRD_REDIS_URL: 'redis://localhost'
-#          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-#          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-#          PYTHON_INTERPRETER: python
-#          SUDO: sudo
-#          ENCHANT_PACKAGE: python3-enchant
-#
-#      - image: cimg/postgres:10.17
-#        environment:
-#          POSTGRES_USER: root
-#          POSTGRES_DB: circle_test
-#          POSTGRES_HOST_AUTH_METHOD: trust
-#
-#      - image: cimg/redis:5.0
-#
-#  pypy-3-9:
-#    <<: *test-template
-#    docker:
-#      - image: pypy:3.9
-#        environment:
-#          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-#          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-#          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-#          IRRD_REDIS_URL: 'redis://localhost'
-#          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-#          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-#          PYTHON_INTERPRETER: pypy3
-#          SUDO: ''
-#          ENCHANT_PACKAGE: python3-enchant
-#
-#      - image: cimg/postgres:10.17
-#        environment:
-#          POSTGRES_USER: root
-#          POSTGRES_DB: circle_test
-#          POSTGRES_HOST_AUTH_METHOD: trust
-#
-#      - image: cimg/redis:5.0
-#
-#  pypy-3-7:
-#    <<: *test-template
-#    docker:
-#      - image: pypy:3.7
-#        environment:
-#          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-#          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-#          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-#          IRRD_REDIS_URL: 'redis://localhost'
-#          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-#          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-#          PYTHON_INTERPRETER: pypy3
-#          SUDO: ''
-#          ENCHANT_PACKAGE: python3-enchant
-#
-#      - image: cimg/postgres:10.17
-#        environment:
-#          POSTGRES_USER: root
-#          POSTGRES_DB: circle_test
-#          POSTGRES_HOST_AUTH_METHOD: trust
-#
-#      - image: cimg/redis:5.0
+  build_docs:
+    parameters:
+      docker_image:
+        type: string
+      python_interpreter:
+        type: string
+        default: python3
+      sudo_command:
+        type: string
+        default: sudo
+
+    resource_class: large
+    docker:
+      - image: << parameters.docker_image >>
+        environment:
+          PYTHON_INTERPRETER: << parameters.python_interpreter >>
+          SUDO: << parameters.sudo_command >>
+
+    working_directory: /mnt/ramdisk
+
+    steps:
+      - checkout
+
+      - run:
+          name: apt update
+          command: |
+            set +e
+            $SUDO apt update
+            echo
+
+      - run:
+          name: Installing and enchant
+          command: $SUDO apt -y install python3-enchant
+
+      - restore_cache:
+          keys:
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+              "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
+
+      - run:
+          name: install latest pip
+          command: |
+            $PYTHON_INTERPRETER -m venv venv
+            . venv/bin/activate
+            pip install -U pip
+
+      - run:
+          name: install dependencies
+          command: |
+            PATH=$PATH:/root/.cargo/bin/
+            $PYTHON_INTERPRETER -m venv venv
+            . venv/bin/activate
+            pip install -Ur requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+            "requirements.txt" }}
+
+      - run:
+          name: build docs
+          command: |
+            . venv/bin/activate
+            sphinx-build -nW -b spelling docs/ docs/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,40 +44,9 @@ workflows:
           docker_image: cimg/python:3.10
 
 
-jobs:
-  unit_tests:
-    parameters:
-      docker_image:
-        type: string
-      python_interpreter:
-        type: string
-        default: python3
-      sudo_command:
-        type: string
-        default: sudo
-
-    resource_class: large
-    docker:
-      - image: << parameters.docker_image >>
-        environment:
-          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-          IRRD_REDIS_URL: 'redis://localhost'
-          PYTHON_INTERPRETER: << parameters.python_interpreter >>
-          SUDO: << parameters.sudo_command >>
-
-      - image: cimg/postgres:10.17
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-
-      - image: cimg/redis:5.0
-
-    working_directory: /mnt/ramdisk
-
+commands:
+  install_dependencies:
     steps:
-      - checkout
-
       - run:
           name: apt update
           command: |
@@ -120,6 +89,50 @@ jobs:
             - ./venv
           key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
             "requirements.txt" }}
+
+  store_results:
+    steps:
+      - store_test_results:
+          path: test-reports
+
+      - store_artifacts:
+          path: /tmp/pytest-of-circleci/
+
+
+
+jobs:
+  unit_tests:
+    parameters:
+      docker_image:
+        type: string
+      python_interpreter:
+        type: string
+        default: python3
+      sudo_command:
+        type: string
+        default: sudo
+
+    resource_class: large
+    working_directory: /mnt/ramdisk
+    docker:
+      - image: << parameters.docker_image >>
+        environment:
+          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
+          IRRD_REDIS_URL: 'redis://localhost'
+          PYTHON_INTERPRETER: << parameters.python_interpreter >>
+          SUDO: << parameters.sudo_command >>
+
+      - image: cimg/postgres:10.17
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+
+      - image: cimg/redis:5.0
+
+    steps:
+      - checkout
+      - install_dependencies
 
       - run:
           name: Waiting for PostgreSQL to be ready
@@ -138,11 +151,7 @@ jobs:
             . venv/bin/activate
             py.test -s -vvvv --cov=irrd irrd --junitxml=test-reports/junit.xml --cov-fail-under=100 --cov-report term-missing:skip-covered
 
-      - store_test_results:
-          path: test-reports
-
-      - store_artifacts:
-          path: /tmp/pytest-of-circleci/
+      - store_results
 
 
   integration_tests:
@@ -157,6 +166,7 @@ jobs:
         default: sudo
 
     resource_class: large
+    working_directory: /mnt/ramdisk
     docker:
       - image: << parameters.docker_image >>
         environment:
@@ -175,53 +185,9 @@ jobs:
 
       - image: cimg/redis:5.0
 
-    working_directory: /mnt/ramdisk
-
     steps:
       - checkout
-
-      - run:
-          name: apt update
-          command: |
-            set +e
-            $SUDO apt update
-            echo
-
-      - run:
-          name: Installing psql client and enchant
-          command: $SUDO apt -y install postgresql-client netcat python3-enchant
-
-      - run:
-          name: Install rust
-          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-      - restore_cache:
-          keys:
-            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
-              "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
-
-      - run:
-          name: install latest pip
-          command: |
-            $PYTHON_INTERPRETER -m venv venv
-            . venv/bin/activate
-            pip install -U pip
-
-      - run:
-          name: install dependencies
-          command: |
-            PATH=$PATH:/root/.cargo/bin/
-            $PYTHON_INTERPRETER -m venv venv
-            . venv/bin/activate
-            pip install -Ur requirements.txt
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
-            "requirements.txt" }}
+      - install_dependencies
 
       - run:
           name: Waiting for PostgreSQL to be ready
@@ -250,8 +216,7 @@ jobs:
             . venv/bin/activate
             py.test irrd/integration_tests/run.py -s
 
-      - store_artifacts:
-          path: /tmp/pytest-of-circleci/
+      - store_results
 
 
   lint:
@@ -266,55 +231,17 @@ jobs:
         default: sudo
 
     resource_class: large
+    working_directory: /mnt/ramdisk
     docker:
       - image: << parameters.docker_image >>
         environment:
           PYTHON_INTERPRETER: << parameters.python_interpreter >>
           SUDO: << parameters.sudo_command >>
 
-    working_directory: /mnt/ramdisk
 
     steps:
       - checkout
-
-      - run:
-          name: apt update
-          command: |
-            set +e
-            $SUDO apt update
-            echo
-
-      - run:
-          name: Install rust
-          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-      - restore_cache:
-          keys:
-            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
-              "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
-
-      - run:
-          name: install latest pip
-          command: |
-            $PYTHON_INTERPRETER -m venv venv
-            . venv/bin/activate
-            pip install -U pip
-
-      - run:
-          name: install dependencies
-          command: |
-            PATH=$PATH:/root/.cargo/bin/
-            $PYTHON_INTERPRETER -m venv venv
-            . venv/bin/activate
-            pip install -Ur requirements.txt
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
-            "requirements.txt" }}
+      - install_dependencies
 
       - run:
           name: run flake8
@@ -341,49 +268,16 @@ jobs:
         default: sudo
 
     resource_class: large
+    working_directory: /mnt/ramdisk
     docker:
       - image: << parameters.docker_image >>
         environment:
           PYTHON_INTERPRETER: << parameters.python_interpreter >>
           SUDO: << parameters.sudo_command >>
 
-    working_directory: /mnt/ramdisk
-
     steps:
       - checkout
-
-      - run:
-          name: apt update
-          command: |
-            set +e
-            $SUDO apt update
-            echo
-
-      - run:
-          name: Installing and enchant
-          command: $SUDO apt -y install python3-enchant
-
-      - restore_cache:
-          keys:
-            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
-              "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
-
-      - run:
-          name: install latest pip
-          command: |
-            $PYTHON_INTERPRETER -m venv venv
-            . venv/bin/activate
-            pip install -U pip
-
-      - run:
-          name: install dependencies
-          command: |
-            PATH=$PATH:/root/.cargo/bin/
-            $PYTHON_INTERPRETER -m venv venv
-            . venv/bin/activate
-            pip install -Ur requirements.txt
+      - install_dependencies
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ workflows:
       - pypy-3.9
       - pypy-3.7
 jobs:
-  cpython-3.7: &test-template
+  cpython-3.7:
+    &test-template
     docker:
       - image: cimg/python:3.7
         environment:
@@ -54,9 +55,10 @@ jobs:
 
       - restore_cache:
           keys:
-          - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+              "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v16-dependencies-{{ .Environment.CIRCLE_JOB }}
 
       - run:
           name: install latest pip
@@ -76,7 +78,8 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "requirements.txt" }}
+          key: v16-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum
+            "requirements.txt" }}
 
       - run:
           name: Waiting for PostgreSQL to be ready
@@ -91,11 +94,13 @@ jobs:
 
       - run:
           name: Creating additional database 1
-          command: psql -U root -h localhost -d circle_test -c "CREATE DATABASE circle_test_integration_1;"
+          command: psql -U root -h localhost -d circle_test -c "CREATE DATABASE
+            circle_test_integration_1;"
 
       - run:
           name: Creating additional database 2
-          command: psql -U root -h localhost -d circle_test -c "CREATE DATABASE circle_test_integration_2;"
+          command: psql -U root -h localhost -d circle_test -c "CREATE DATABASE
+            circle_test_integration_2;"
 
       - run:
           name: run regular tests
@@ -155,6 +160,8 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
 
       - image: cimg/redis:5.0
+    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: large
 
   pypy-3.9:
     <<: *test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,40 @@
 #
 version: 2.1
 workflows:
-  test:
+  test-all:
     jobs:
-      - cpython-3-7
-      - cpython-3-10
-      - pypy-3-9
-      - pypy-3-7
+      - unit_tests:
+          name: unit-tests-cpython-3-7
+          docker_image: cimg/python:3.7
+      - unit_tests:
+          name: unit-tests-cpython-3-10
+          docker_image: cimg/python:3.10
+      - unit_tests:
+          name: unit-tests-pypy-3-7
+          python_interpreter: pypy3
+          docker_image: pypy:3.7
+          sudo_command: ''
+      - unit_tests:
+          name: unit-tests-pypy-3.9
+          docker_image: pypy:3.7
+          python_interpreter: pypy3
+          sudo_command: ''
+
 jobs:
-  cpython-3-7:
-    &test-template
+  unit_tests:
+    parameters:
+      docker_image:
+        type: string
+      python_interpreter:
+        type: string
+        default: python3
+      sudo_command:
+        type: string
+        default: sudo
+
     resource_class: large
     docker:
-      - image: cimg/python:3.7
+      - image: << parameters.docker_image >>
         environment:
           IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
           IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
@@ -21,9 +43,8 @@ jobs:
           IRRD_REDIS_URL: 'redis://localhost'
           IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
           IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-          PYTHON_INTERPRETER: python3
-          SUDO: sudo
-          ENCHANT_PACKAGE: python3-enchant
+          PYTHON_INTERPRETER: << parameters.python_interpreter >>
+          SUDO: << parameters.sudo_command >>
 
       - image: cimg/postgres:10.17
         environment:
@@ -47,7 +68,7 @@ jobs:
 
       - run:
           name: Installing psql client and enchant
-          command: $SUDO apt -y install postgresql-client netcat $ENCHANT_PACKAGE
+          command: $SUDO apt -y install postgresql-client netcat python3-enchant
 
       - run:
           name: Install rust
@@ -137,72 +158,72 @@ jobs:
 
       - store_artifacts:
           path: /tmp/pytest-of-circleci/
-
-  cpython-3-10:
-    <<: *test-template
-    docker:
-      - image: cimg/python:3.10
-        environment:
-          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-          IRRD_REDIS_URL: 'redis://localhost'
-          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-          PYTHON_INTERPRETER: python
-          SUDO: sudo
-          ENCHANT_PACKAGE: python3-enchant
-
-      - image: cimg/postgres:10.17
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-
-      - image: cimg/redis:5.0
-
-  pypy-3-9:
-    <<: *test-template
-    docker:
-      - image: pypy:3.9
-        environment:
-          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-          IRRD_REDIS_URL: 'redis://localhost'
-          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-          PYTHON_INTERPRETER: pypy3
-          SUDO: sudo
-          ENCHANT_PACKAGE: python3-enchant
-
-      - image: cimg/postgres:10.17
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-
-      - image: cimg/redis:5.0
-
-  pypy-3-7:
-    <<: *test-template
-    docker:
-      - image: pypy:3.7
-        environment:
-          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-          IRRD_REDIS_URL: 'redis://localhost'
-          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-          PYTHON_INTERPRETER: pypy3
-          SUDO: sudo
-          ENCHANT_PACKAGE: python3-enchant
-
-      - image: cimg/postgres:10.17
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-
-      - image: cimg/redis:5.0
+#
+#  cpython-3-10:
+#    <<: *test-template
+#    docker:
+#      - image: cimg/python:3.10
+#        environment:
+#          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
+#          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
+#          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
+#          IRRD_REDIS_URL: 'redis://localhost'
+#          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
+#          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
+#          PYTHON_INTERPRETER: python
+#          SUDO: sudo
+#          ENCHANT_PACKAGE: python3-enchant
+#
+#      - image: cimg/postgres:10.17
+#        environment:
+#          POSTGRES_USER: root
+#          POSTGRES_DB: circle_test
+#          POSTGRES_HOST_AUTH_METHOD: trust
+#
+#      - image: cimg/redis:5.0
+#
+#  pypy-3-9:
+#    <<: *test-template
+#    docker:
+#      - image: pypy:3.9
+#        environment:
+#          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
+#          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
+#          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
+#          IRRD_REDIS_URL: 'redis://localhost'
+#          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
+#          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
+#          PYTHON_INTERPRETER: pypy3
+#          SUDO: ''
+#          ENCHANT_PACKAGE: python3-enchant
+#
+#      - image: cimg/postgres:10.17
+#        environment:
+#          POSTGRES_USER: root
+#          POSTGRES_DB: circle_test
+#          POSTGRES_HOST_AUTH_METHOD: trust
+#
+#      - image: cimg/redis:5.0
+#
+#  pypy-3-7:
+#    <<: *test-template
+#    docker:
+#      - image: pypy:3.7
+#        environment:
+#          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
+#          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
+#          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
+#          IRRD_REDIS_URL: 'redis://localhost'
+#          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
+#          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
+#          PYTHON_INTERPRETER: pypy3
+#          SUDO: ''
+#          ENCHANT_PACKAGE: python3-enchant
+#
+#      - image: cimg/postgres:10.17
+#        environment:
+#          POSTGRES_USER: root
+#          POSTGRES_DB: circle_test
+#          POSTGRES_HOST_AUTH_METHOD: trust
+#
+#      - image: cimg/redis:5.0


### PR DESCRIPTION
This allows many more CI jobs run parallel. There is some cost in duplicate dependency installs, but as we get free parallel jobs it doesn't really have much impact. We could also fix that by having a prebuild step to build a cache for each Python version, but not really worth it.