### PR TITLE
Route order preference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ commands:
             PATH=$PATH:/root/.cargo/bin/
             $PYTHON_INTERPRETER -m venv venv
             . venv/bin/activate
-            pip install -Ur requirements.txt
+            pip install -vUr requirements.txt
 
       - save_cache:
           paths:

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -533,6 +533,21 @@ Scope filter
   |br| **Change takes effect**: after SIGHUP. Updating the status of
   existing objects may take 10-15 minutes.
 
+Route object preference
+~~~~~~~~~~~~~~~~~~~~~~~
+* ``route_object_preference.update_timer``: the time in seconds between
+  full updates of the
+  :doc:`route object preference </admins/route-object-preference>` status
+  for all objects in the database. Note that the status is already updated
+  on changes to objects as they are processed - this periodic process sets
+  the initial state and resolver small inconsistencies. This setting
+  has no effect unless at least one source has
+  ``sources.{name}.route_object_preference`` set.
+  |br| **Default**: 3600 (1 hour)
+  |br| **Change takes effect**: after SIGHUP.
+
+In addition to this, the route object preference of each source can be set
+in ``sources.{name}.route_object_preference``, documented below.
 
 Sources
 ~~~~~~~
@@ -665,7 +680,12 @@ Sources
   this source. If set to ``true``, all objects will be considered in scope
   for their scope filter status.
   |br| **Default**: false, scope filter validation enabled.
-  |br| **Change takes effect**: after SIGHUP, within a few minutes
+  |br| **Change takes effect**: after SIGHUP, within a few minutes.
+* ``sources.{name}.route_object_preference``: the
+  :doc:`route object preference </admins/route-object-preference>` for
+  this source. Higher number is a higher preference.
+  |br| **Default**: unset, not considered for route object preference.
+  |br| **Change takes effect**: after SIGHUP, after next periodic update.
 * ``sources.{name}.suspension_enabled``: a boolean for whether this source
   allows :doc:`suspension and reactivation of objects </admins/suspension>`.
   Can only be enabled if `authoritative` is enabled.

--- a/docs/admins/object-suppression.rst
+++ b/docs/admins/object-suppression.rst
@@ -1,0 +1,145 @@
+===========================
+Object suppression overview
+===========================
+
+IRRd supports three methods to suppress objects:
+
+* :doc:`RPKI </admins/rpki>`, where IRRd suppresses objects that are
+  invalid according to
+  `RFC6811 origin validation <https://tools.ietf.org/html/rfc6811>`_.
+  In addition, IRRd will create pseudo-IRR objects representing ROAs.
+* The :doc:`scope filter </admins/scopefilter>`, which suppresses objects
+  matching certain configured prefixes and/or AS numbers.
+* The :doc:`route object preference </admins/route-object-preference>`,
+  which suppresses objects that overlap with other route objects from
+  sources with a higher preference.
+
+Suppression is a kind of pseudo delete/create: IRRd will act as if the
+object was deleted, but it may become visible again later.
+One exception is that suppressed objects may still be deleted and can
+still conflict on primary key.
+Unlike normal deletions and creations,
+this visibility change may have an external cause, e.g. a new ROA created
+by the address space holder, or a change in scope filter configuration.
+Suppression can also apply to objects for which the instance
+is not authoritative.
+
+When IRRd evaluates suppression
+-------------------------------
+* RPKI and route object preference periodically update the status for all
+  relevant objects in the database. This resolves issues around temporary
+  inconsistencies and, for RPKI, is also the moment when the local ROA
+  storage is updated.
+* For RPKI, this happens every ``rpki.roa_import_timer`` and for route object
+  preference every ``route_object_preference.update_timer``.
+  The scope filter updates all statuses on startup and then after any
+  configuration change.
+* When IRRd receives objects from mirrors, in full imports or over NRTM,
+  the RPKI, scope filter and route preference status of these objects is updated.
+* When users create an object for which the IRRd instance is authoritative,
+  the scope filter and RPKI will reject creation of a suppressed object.
+
+Scope of suppression
+--------------------
+Suppressed objects are not visible in the responses to queries,
+database exports, NRTM streams, or the event stream.
+
+To aid in debugging, it is possible to include suppressed objects in some
+query responses. On whois queries, you can use the ``!fno-rpki-filter``,
+``!fno-scope-filter``, and/or ``!fno-route-preference-filter`` commands.
+The filter is then disabled only for ``!r`` queries and all RIPE style
+queries. In GraphQL ``rpslObjects`` queries, you can pass a specific list of
+``rpkiStatus``, ``scopeFilterStatus``, and/or ``routePreferenceStatus``
+to include in the response.
+
+Recording in the local journal
+------------------------------
+Object suppression is reflected in the journal so that mirrors from
+the IRRd instance follow with the suppression. This means that
+IRRd does not record an ADD for suppressed objects, and if an existing
+object changes from visible to suppressed, IRRd records a DEL.
+If an already suppressed object is deleted by the mirror source,
+IRRd does not record any journal entry.
+
+An example: your IRRd
+mirrors source DEMO from the authoritative source, you keep a local journal, and
+a third party mirrors DEMO from you. When the authoritative source for
+DEMO sends an NRTM ADD for an RPKI invalid route, that update is not
+recorded in your IRRd's local journal. The third party that mirrors from
+you will not see this ADD over NRTM.
+
+If a ROA is added the next day that results in the route being RPKI valid
+or not_found, an ADD is recorded in the local journal, and the third party
+can pick up the change from an NRTM query to your IRRd. If that ROA is
+deleted again, causing the route to return to RPKI invalid, a DEL is
+recorded in your local journal.
+
+Therefore, both the local state of your IRRd, and anyone mirroring from
+your IRRd, will be up to date with the RPKI status.
+
+For route object preference, there are cases where IRRd records an ADD
+and then immediately a DEL for the same object.
+
+Interaction between suppression statuses
+----------------------------------------
+Each suppression status is independent, but for the visibility in
+the journal and query responses, IRRd considers the combined state:
+an object is suppressed if any of the suppression methods see it as
+suppressed.
+
+Following on the previous example: if along with the RPKI state,
+the object is out of scope according to the scope filter, IRRd will
+not generate an ADD in the journal at any point, and the object
+will never be visible in query responses.
+
+Important considerations when enabling
+--------------------------------------
+When you enable one of these features for the first time, the periodic
+task will usually take considerably longer than on subsequent runs.
+On the first run, a large number of objects in the database may need to
+be updated, whereas this number is much smaller on subsequent runs.
+The same may occur after changing settings, if these change a large number
+of objects.
+
+While the import and validation is running, processing other
+database changes may be delayed.
+
+These large status changes may also generate a significant amount
+of local journal entries, which are used to generate NRTM responses
+for anyone mirroring any source from your IRRd. Depending on the
+sources, there may be in the order of 100K-1M journal entries.
+NRTM is really not designed for this scale, and therefore it is
+likely faster to have mirrors reload their copy.
+
+Writing such huge numbers of changes to the journal also takes
+considerable time.
+If you are planning to require mirrors to reload their copies,
+you may want to disable the ``keep_journal``
+setting on one or more sources for the initial status update.
+This speeds up the process dramatically, but means you must
+make sure all mirrors reload their copy after you have re-enabled
+the journal. Otherwise, they will desynchronise silently.
+
+Temporary inconsistencies
+-------------------------
+There are a number situations that can cause temporary inconsistencies for
+RPKI and route object preference, because multiple processes depend on
+each other's state. These are usually small, and automatically resolved
+on the next periodic update, which considers the state of the whole database.
+
+For example:
+when you enable RPKI-aware mode and **at the same time** add a new source,
+the objects for the new source may not have the correct RPKI status
+initially. This happens because in the new source import process, no ROAs
+are visible, and to the periodic ROA update, the objects in the new source
+are not visible yet. This situation automatically resolves itself upon
+the next periodic ROA update, but may cause objects that should be marked
+RPKI-invalid to be included in responses in the mean time.
+
+Similarly: a case where two mirror imports with different route object
+preferences run at the precise same time, and both include a `route` object
+for there same prefix. IRRd will record both as visible, because neither
+mirror process was able to see the other's object. This also resolves
+on the next periodic full route object preference update.
+Generally, the timing of these processes is slightly different, making
+this a rare issue.

--- a/docs/admins/object-validation.rst
+++ b/docs/admins/object-validation.rst
@@ -7,8 +7,8 @@ However, most current IRR databases violate these RFCs in some
 ways, meaning some flexibility is needed.
 
 In addition to the validations as described below, IRRd supports
-an :doc:`RPKI-aware mode </admins/rpki>` where objects are also
-validated against ROAs.
+:doc:`object suppression </admins/object-suppression>` where objects are also
+filtered or validated against ROAs, a scope filter, or other route objects.
 
 
 General requirements
@@ -19,13 +19,13 @@ The general requirements for validation are:
 * Any objects submitted to IRRd directly (i.e. not from mirrors)
   should always be entirely valid. If they are not, the end user
   can fix their object and continue from there.
-* The NTTCOM database has some legacy objects which require more
+* Many databases have some legacy objects which require more
   leniency with an initial import, but we aim to be as restrictive
   as reasonably possible. It should not be possible to update invalid
-  objects without correcting their issues.
+  authoritative objects without correcting their issues.
 * Mirrors contain wildly variant objects, so IRRd performs the minimal
   level of validation needed to correctly index and query them.
-* Under no condition may IRRd provide responses to any query, which
+* IRRd must never provide responses to any query, which
   are missing certain objects because indexed data could not be extracted
   from them, without logging errors about failing to import these objects.
 * If objects are received from mirrors that can not be accepted, e.g.
@@ -100,6 +100,7 @@ The ``rpki-ov-state`` attribute, which is used to indicate the
 :doc:`RPKI validation status </admins/rpki>`, is always discarded from all
 incoming objects. Where relevant, it is added to the output of queries.
 This applies to authoritative and non-authoritative sources.
+This attribute is not visible over NRTM and in exports.
 
 key-cert objects
 ^^^^^^^^^^^^^^^^
@@ -114,7 +115,7 @@ last-modified
 ^^^^^^^^^^^^^
 For authoritative objects, the ``last-modified`` attribute is set when
 the object is created or updated. Any existing ``last-modified`` values are
-discarded. This timestamp is not updated for changes in RPKI validation
+discarded. This timestamp is not updated for changes in object suppression
 status. This attribute is visible over NRTM and in exports.
 
 By default, this attribute is only added when an object is changed or

--- a/docs/admins/route-object-preference.rst
+++ b/docs/admins/route-object-preference.rst
@@ -1,0 +1,95 @@
+=======================
+Route object preference
+=======================
+
+IRRd supports a route object preference, where `route(6)` objects can
+be suppressed if they overlap with other `route(6)` objects from sources
+with a higher route object preference.
+
+.. note::
+   This document only contains details specific to the filter, and is
+   meant to complement the
+   :doc:`object suppression overview </admins/object-suppression>`.
+
+.. contents::
+   :backlinks: none
+   :local:
+
+Configuring route object preference
+-----------------------------------
+You can enable route object preference by setting
+``sources.{name}.route_object_preference`` on at least one source.
+This is a number, where higher numbers have higher preference. See the
+:doc:`configuration documentation </admins/configuration>` for the
+exact syntax.
+
+You can exclude sources by **not** setting
+``sources.{name}.route_object_preference``.
+Objects from these sources are always seen as visible.
+
+To disable this feature, set ``route_object_preference`` for all sources
+to the same preference to reset the state of all objects to visible.
+Once the periodic
+import has updated this, unset ``sources.{name}.route_object_preference``
+for all sources to disable the update process.
+
+Validation
+----------
+* In route object preference, each `route(6)` object is assigned a preference
+  from its source's ``sources.{name}.route_object_preference`` setting.
+* For the objects with a preference: if there is an overlapping
+  `route(6)` object with a higher preference, the lower preference object
+  is suppressed.
+* Overlap means that the prefixes of the objects are an exact match, more
+  specific, or less specific.
+* If two overlapping objects have the same preference, both are visible
+  (assuming there are no further overlaps).
+* Origin ASes are not considered.
+* Objects from sources without a preference setting are always visible and
+  otherwise completely ignored in the validation process. They are also not
+  included when considering suppression of other objects.
+
+For example, let's say the preferences are: TEST-H1 and TEST-H2 at
+priority 900, TEST-M at 200, TEST-L at 100, TEST-N with no preference,
+and the following objects exist:
+
+* A: TEST-H1 192.0.0.0/23 AS65530
+* B: TEST-H2 192.0.0.0/24 AS65530
+* C: TEST-L 192.0.0.0/23 AS65530
+* D: TEST-M 192.0.0.0/22 AS65530
+* E: TEST-M 192.0.1.0/24 AS65530
+* F: TEST-L 192.0.3.0/24 AS65530
+* G: TEST-N 192.0.0.0/22 AS65530
+
+In this case objects C, D, E and F will be suppressed.
+C, D and E all overlap directly with A and/or B, and A and B have a higher
+preference than all others. A and B have an identical preference so their
+objects will both be visible. Object F overlaps with object D, and object D
+has a higher preference, therefore object F is also suppressed.
+Object G remains visible and is otherwise ignored, as it has no
+preference set, so it has no impact on the visibility of other objects.
+
+Log messages and journal order
+------------------------------
+RPKI and scope filter status are determined per object,
+shortly after parsing. Route preference status is rather difference:
+it is determined for all affected prefixes just before committing.
+This has some practical consequences that may lead to initially
+confusing log messages or journal entries.
+
+In RPKI and scope filter, the status of an object can be determined
+by evaluating only that object, and the IRRd configuration and/or ROA table.
+However, for route preference, an object's status depends on which
+other objects exist in other sources. Also, uniquely, one object
+being added or deleted, may cause the state of an entirely different
+object to change, which was not part of the current change set.
+
+When evaluating the status just before a transaction commit, IRRd
+will log a line like:
+`route preference updated for a subset of 15 added/removed/changed
+routes: 2 regular objects made visible, 8 regular objects suppressed,
+0 objects from excluded sources made visible`.
+Important to note is that the 15 added/removed/changed routes do not
+have to be the same objects as the 2 objects made visible, and the 8 made
+suppressed. Similarly, processing NRTM changes from one source, may
+lead to journal entries for objects of an entirely different source.

--- a/docs/admins/rpki.rst
+++ b/docs/admins/rpki.rst
@@ -3,14 +3,19 @@ RPKI integration
 ================
 
 IRRd can operate in RPKI-aware mode, where it imports ROA objects and
-uses those to validate `route(6)` objects. IRRd also generates pseudo-IRR
+uses those to suppress `route(6)` objects. IRRd also generates pseudo-IRR
 objects that represent ROA data.
+
+.. note::
+   This document only contains details specific to the scope filter, and is
+   meant to complement the
+   :doc:`object suppression overview </admins/object-suppression>`.
 
 .. contents::
    :backlinks: none
 
-Enabling RPKI-aware mode
-------------------------
+Configuring RPKI-aware mode
+---------------------------
 You can enable RPKI-aware mode by setting ``rpki.roa_source``
 to a URL of a ROA export in JSON format. RPKI-aware mode is **enabled**
 by default. To disable RPKI-aware mode, set this to ``null``.
@@ -18,6 +23,14 @@ by default. To disable RPKI-aware mode, set this to ``null``.
 As soon as this is enabled and you (re)start IRRd or send a SIGHUP,
 IRRd will import the ROAs and mark any invalid existing `route(6)` as
 such in the database.
+
+You can exclude sources by setting ``sources.{name}.rpki_excluded``.
+Objects from these sources are always seen as ``not_found``.
+
+To disable the RPKI filter, set ``rpki_excluded`` for all sources
+to reset the state of all objects to ``not_found``. Once the periodic
+import has updated the state of all objects,
+unset ``rpki.roa_source`` to disable the RPKI update process.
 
 Pseudo-IRR objects
 ------------------
@@ -29,59 +42,18 @@ is enabled. The ``RPKI`` source can be enabled or disabled like any
 other source with ``!s`` and ``-s``, and can be included in the
 ``sources_default`` setting to be included in responses by default.
 
+Validation
+----------
+IRRd uses `RFC6811 origin validation <https://tools.ietf.org/html/rfc6811>`_.
+Objects that are RPKI invalid are suppressed.
+
 Query responses
 ---------------
-By default, `route(6)` objects that conflict with a ROA are not included
-in any query response. This is determined using
-`RFC6811 origin validation <https://tools.ietf.org/html/rfc6811>`_ and
-applies to all query types.
-
-Query responses for the text of `route(6)` objects include a
+In addition to filtering suppressed objects from queries,
+query responses for the text of `route(6)` objects include a
 ``rpki-ov-state`` attribute, showing the current status.
 This attribute is discarded from any objects submitted to IRRd,
 and omitted for pseudo-IRR objects.
-
-To aid in debugging, it is possible to include invalid objects in the
-response. The RPKI filter can be disabled for a connection with the
-``!fno-rpki-filter`` command. The filter is
-disabled only for ``!r`` queries and all RIPE style queries.
-
-Where validation takes place
-----------------------------
-* Every ``rpki.roa_import_timer``, IRRd re-imports the ROA file, and then
-  updates the validation status of all `route(6)` objects in the IRR database.
-  This ensures that the status is correct when ROAs are added or removed.
-* For each imported object from NRTM, periodic full imports, or manual data
-  loading, IRRd sets the validation status using the current known ROAs, both
-  on creations or changes.
-* IRRd checks creation or modification of objects in authoritative databases
-  against the ROAs, and rejects the objects when they are RPKI invalid.
-* Deletions of RPKI invalid object are permitted, both for authoritative
-  database and when receiving deletions over NRTM.
-* IRRd will always set objects from sources with
-  ``sources.{name}.rpki_excluded`` set to status not_found,
-  i.e. they are never regarded as RPKI invalid objects at any time.
-* Database exports and NRTM streams will not include RPKI invalid objects.
-* If the validation state changes, e.g. due to a new ROA, an NRTM ADD
-  or DEL is created in the journal.
-
-An example of validation in the context of mirroring: your IRRd
-mirrors source DEMO the authoritative source, you keep a local journal, and
-a third party mirrors DEMO from you. When the authoritative source for
-DEMO sends an NRTM ADD for an RPKI invalid route, that update is not
-recorded in your IRRd's local journal. The third party that mirrors from
-you will not see this ADD over NRTM.
-
-If a ROA is added the next day that results in the route being RPKI valid
-or not_found, an ADD is recorded in the local journal, and the third party
-can pick up the change from an NRTM query to your IRRd. If that ROA is
-deleted again, causing the route to return to RPKI invalid, a DEL is
-recorded in your local journal.
-
-Therefore, both the local state of your IRRd, and anyone mirroring from
-your IRRd, will be up to date with the RPKI status.
-This does not apply to excluded sources, whose objects are never seen
-as RPKI invalid.
 
 .. _rpki-notifications:
 
@@ -115,46 +87,23 @@ Notifications are never sent for objects from non-authoritative sources.
 
 First import with RPKI-aware mode
 ---------------------------------
-When you first enable RPKI-aware mode, the import and validation process
-will take considerably longer than on subsequent runs. On the first run,
-a large number of objects in the database need to be updated, whereas this
-number is much smaller on subsequent runs.
-Depending on ``rpki.notify_invalid_enabled``, many emails may be sent out
-as well. While the import and validation is running, processing other
-database changes may be delayed.
-
-The first full import after changing ``sources.{name}.rpki_excluded``
-may also be slower, for the same reason.
-
-.. note::
-    The first RPKI-aware import may also generate a significant amount
-    of local journal entries, which are used to generate NRTM responses
-    for anyone mirroring any source from your IRRd. Depending on the
-    sources, there may be up to 200.000 NRTM updates. It may be faster
-    to have mirrors reload their copy, as NRTM was not designed
-    for this volume.
+Along with the concerns mentioned in
+:doc:`object suppression </admins/object-suppression>`, depending on
+``rpki.notify_invalid_enabled``, many emails may be sent out
+as well.
 
 Temporary inconsistencies
 -------------------------
-There are three situations that can cause temporary RPKI inconsistencies.
+In addition to the cases documented in the
+:doc:`object suppression </admins/object-suppression>` documentation,
+there are two situations that can cause temporary RPKI inconsistencies.
 
-First, when you enable RPKI-aware mode and **at the same time** add a new source,
-the objects for the new source may not have the correct RPKI status
-initially. This happens because in the new source import process, no ROAs
-are visible, and to the periodic ROA update, the objects in the new source
-are not visible yet. This situation automatically resolves itself upon
-the next periodic ROA update, but may cause objects that should be marked
-RPKI-invalid to be included in responses in the mean time.
-This issue only occurs when RPKI-aware mode is enabled for the first time,
-and at the same time a new source is added. At other times, the RPKI
-status of new sources will be correct.
-
-Second, when someone adds a ROA and a `route` object in a mirrored source,
+First, when someone adds a ROA and a `route` object in a mirrored source,
 the ROA may not be imported by the time the `route` object is received
 over NRTM. The object may initially be marked as RPKI not_found, or, depending
 on the ROA change, as invalid. This will be resolved at the next ROA import.
 
-Third, when someone attempts to create a `route` object in an authoritative
+Second, when someone attempts to create a `route` object in an authoritative
 source and has just created or modified a ROA, the ROA may not have been
 imported yet. This can cause the object to be initially marked as RPKI
 not_found, or if the `route` is RPKI invalid without the ROA change,

--- a/docs/admins/scopefilter.rst
+++ b/docs/admins/scopefilter.rst
@@ -3,34 +3,39 @@ Scope filtering
 ===============
 
 IRRd supports a scope filter, where RPSL objects matching certain prefixes
-and AS numbers can be filtered.
+and AS numbers can be suppressed.
+
+.. note::
+   This document only contains details specific to the scope filter, and is
+   meant to complement the
+   :doc:`object suppression overview </admins/object-suppression>`.
 
 .. contents::
    :backlinks: none
    :local:
 
-Enabling the scope filter
--------------------------
+Configuring the scope filter
+----------------------------
 You can enable the scope filter by setting ``scopefilter.prefixes``
 and/or ``scopefilter.asns``. See the
 :doc:`configuration documentation </admins/configuration>` for their
 exact syntax.
 
 As soon as this is enabled and you (re)start IRRd or send a SIGHUP,
-IRRd will check all RPSL in the database against the scope filter.
+IRRd will check all objects in the database against the scope filter.
 
-Query responses
----------------
-By default, RPSL objects that are out of scope are not included in
-in any query response.
+You can exclude sources by setting ``sources.{name}.scopefilter_excluded``.
+Objects from these sources are always seen as in scope.
 
-To aid in debugging, it is possible to include out of scope objects in the
-response. The filter can be disabled for a connection with the
-``!fno-scope-filter`` command. The filter is
-disabled only for ``!r`` queries and all RIPE style queries.
+To disable the scope filter, set ``scopefilter_excluded`` for all sources
+to reset the state of all objects to in scope. Once the periodic
+import has updated the status for all objects, unset ``scopefilter.prefixes``
+and ``scopefilter.asns`` to disable the update process.
 
-Objects that may be filtered
-----------------------------
+Validation
+----------
+RPSL objects that are out of scope are suppressed:
+
 * A `route(6)` object is out of scope if the origin is out of scope,
   or the prefix overlaps with any out of scope prefix.
 * An `aut-num` object is out of scope if its primary key is an out of
@@ -39,47 +44,3 @@ Objects that may be filtered
 
 "Overlaps" for prefixes includes an exact match, less specific or more
 specific of a prefix in ``scopefilter.prefixes``.
-
-Where validation takes place
-----------------------------
-* IRRd validates all objects in the database against the scope filter on
-  startup, and if the ``scopefilter`` setting is changed and a SIGHUP is sent.
-* For each imported object from NRTM, periodic full imports, or manual data
-  loading, IRRd sets the scope filter status using the current configuration,
-  both on creations or changes.
-* IRRd checks creation of objects in authoritative databases
-  against the filter, and rejects the objects when they are out of scope.
-  Updates and deletions are permitted.
-* IRRd will always set objects from sources with
-  ``sources.{name}.scopefilter_excluded`` as in scope,
-  i.e. they are never regarded as out of scope objects at any time.
-* Database exports and NRTM streams will not include out of scope
-  objects. NRTM streams will include deletions.
-* If the status of an object changes, due to a configuration change,
-  an NRTM ADD or DEL is created in the journal.
-* The scope filter also applies to
-  :doc:`pseudo-IRR objects generated from ROAs </admins/rpki>`.
-
-An example of validation in the context of mirroring: your IRRd
-mirrors source DEMO from the authoritative source, you keep a local journal,
-and a third party mirrors DEMO from you. When the authoritative source for
-DEMO sends an NRTM ADD for an out of scope route, that update is not
-recorded in your IRRd's local journal. The third party that mirrors from
-you will not see this ADD over NRTM.
-
-If you change the configuration later that results in the route being
-in scope, an ADD is recorded in the local journal, and the third party
-can pick up the change from an NRTM query to your IRRd. If that route becomes
-out of scope again, causing the route to return to out of scope, a DEL is
-recorded in your local journal.
-
-Therefore, both the local state of your IRRd, and anyone mirroring from
-your IRRd, will be up to date with the filter status.
-This does not apply to excluded sources, whose objects are never seen
-as out of scope.
-
-.. note::
-    When first enabling the scope filter, it may generate a significant amount
-    of local journal entries, which are used to generate NRTM responses
-    for anyone mirroring any source from your IRRd. Depending on the
-    sources, there may be a few thousand NRTM updates.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,12 +53,20 @@ This documentation is mainly for administrators of IRRd deployments.
    admins/configuration
    admins/availability-and-migration
    admins/migrating-legacy-irrd
-   admins/object-validation
    admins/status_page
+   admins/faq
+
+
+.. toctree::
+   :caption: Validation, suppression and suspension
+   :maxdepth: 1
+
+   admins/object-validation
+   admins/object-suppression
    admins/rpki
    admins/scopefilter
+   admins/route-object-preference
    admins/suspension
-   admins/faq
 
 Running queries
 ---------------

--- a/docs/releases/4.3.0.rst
+++ b/docs/releases/4.3.0.rst
@@ -80,6 +80,14 @@ Suspended objects act as if they have been deleted, but can be restored by an
 admin at a later time.
 
 
+Support for route object preference
+-----------------------------------
+IRRd can now use
+:doc:`route object preference </admins/route-object-preference>`
+to suppress overlapping `route(6)` objects from different sources,
+based on a configured priority for each source.
+
+
 Support for event stream
 ------------------------
 IRRd now offers a :doc:`WebSocket-based event stream </users/queries/event-stream>`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -23,6 +23,7 @@ conf
 config
 cron
 daemonised
+desynchronise
 dev
 enums
 gpg

--- a/docs/users/queries/event-stream.rst
+++ b/docs/users/queries/event-stream.rst
@@ -206,9 +206,7 @@ Filtering
 ---------
 Password hashes from `mntner` objects are removed in all output.
 
-When a server is in :doc:`RPKI-aware mode </admins/rpki>` or has
-the :doc:`scopefilter </admins/scopefilter>` enabled, IRR objects
-that are out of scope or RPKI invalid are omitted in the initial
-retrieval. Objects that become RPKI invalid or out of scope
-are included in the WebSocket stream as a deletion, with the
+:doc:`Suppressed objects </admins/object-suppression>` are omitted
+in the initial retrieval. Objects that change suppression status
+are included in the WebSocket stream as an add/delete, with the
 ``origin`` indicating this reason.

--- a/docs/users/queries/graphql.rst
+++ b/docs/users/queries/graphql.rst
@@ -466,6 +466,7 @@ The query is defined as follows::
         asn: [ASN!]
         rpkiStatus: [RPKIStatus!]
         scopeFilterStatus: [ScopeFilterStatus!]
+        routePreferenceStatus: [RoutePreferenceStatus!]
         textSearch: String
         recordLimit: Int
         sqlTrace: Boolean
@@ -494,6 +495,10 @@ The other possible arguments for the query are:
   statuses in the database. If omitted, the default is to filter on
   in_scope objects. Valid values are defined in the ``ScopeFilterStatus``
   enum in the schema.
+* ``routePreferenceStatus``: filter on objects that have one of these
+  route preference statuses in the database.
+  If omitted, the default is to filter on visible objects. Valid values are
+  defined in the ``RoutePreferenceStatus`` enum in the schema.
 * ``recordLimit``: limits the query to return this many results. Related
   object query results (explained in detail later) do not count towards
   this limit.
@@ -862,8 +867,8 @@ IRRd has a few custom types for specific purposes:
   sufficient.
 * The ``IP`` scalar. This is presented as a string. When used in query
   arguments, the value is validated to be a valid IP address or prefix.
-* The enums ``RPKIStatus`` and ``ScopeFilterStatus`` for querying and
-  returning these statuses on RPSL objects.
+* The enums ``RPKIStatus``, ``ScopeFilterStatus``, and ``RoutePreferenceStatus``
+  for querying and returning these statuses on RPSL objects.
 
 Tips
 ----

--- a/docs/users/queries/whois.rst
+++ b/docs/users/queries/whois.rst
@@ -98,6 +98,10 @@ IRRd style queries
   * ``object_class_filter``: may be a list of object classes that are
     ignored by this IRRd instance, when mirroring from a remote source.
   * ``rpki_rov_filter``: whether RPKI validation is enabled for this source.
+  * ``scopefilter_enabled``: whether the scope filter is enabled on this instance,
+    and is also enabled for this source.
+  * ``route_preference``: the route order preference setting for this source,
+    if any is set.
   * ``local_journal_kept``: whether this IRRd instance keeps a local journal
     of the changes in this source, allowing it to be mirrored over NRTM.
   * ``serial_oldest_journal`` / ``serial_newest_journal``: the oldest and
@@ -145,12 +149,10 @@ IRRd style queries
   comma-separated, e.g. ``!sRIPE,NTTCOM``. In addition, ``!s-lc`` returns the
   sources currently selected. This persists across queries.
 * ``!v`` returns the current version of IRRd
-* ``!fno-rpki-filter`` disables filtering RPKI invalid routes. If
-  :doc:`RPKI-aware mode is enabled </admins/rpki>`, `route(6)` objects that
-  are RPKI invalid are not included in the output of any query by default.
-  After using ``!fno-rpki-filter``, this filter is disabled for the remainder of
-  the connection. Disabling the filter only applies to ``!r`` queries and
-  all RIPE style queries. This is only intended as a debugging aid.
+* ``!fno-rpki-filter``, ``!fno-scope-filter``, and ``!fno-route-preference-filter``
+  disables the filtering of :doc:`suppressed objects </admins/object-suppression>`
+  for the remainder of the connection. Disabling the filter only applies to ``!r``
+  queries and all RIPE style queries. This is only intended as a debugging aid.
 * ``!fno-scope-filter`` disables filtering out-of-scope objects. If
   the scope filter is enabled, objects that are
   :doc:`out of scope </admins/scopefilter>` are not included in the output of any query by default.

--- a/irrd/conf/default_config.yaml
+++ b/irrd/conf/default_config.yaml
@@ -2,6 +2,8 @@
 # in conf/defaults.py.
 irrd:
     database_url: null
+    route_object_preference:
+        update_timer: 3600
     rpki:
         roa_source: https://rpki.gin.ntt.net/api/export.json
         roa_import_timer: 3600

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -28,6 +28,7 @@ KNOWN_CONFIG_KEYS = DottedDict({
             'max_connections': {},
         },
     },
+    'route_object_preference': {'update_timer': {}},
     'email': {
         'from': {},
         'footer': {},
@@ -95,4 +96,5 @@ KNOWN_SOURCES_KEYS = {
     'rpki_excluded',
     'scopefilter_excluded',
     'suspension_enabled',
+    'route_object_preference',
 }

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -57,6 +57,9 @@ class TestConfiguration:
                     'from': 'example@example.com',
                     'smtp': '192.0.2.1'
                 },
+                'route_object_preference': {
+                    'update_timer': 10,
+                },
                 'rpki': {
                     'roa_source': None,
                 },
@@ -102,6 +105,7 @@ class TestConfiguration:
                         'nrtm_port': 43,
                         'import_serial_source': 'ftp://example.com/serial',
                         'keep_journal': True,
+                        'route_object_preference': 200,
                     },
                     'TESTDB3': {
                         'export_destination_unfiltered': '/tmp',
@@ -272,6 +276,9 @@ class TestConfiguration:
                         'crypt-pw': 'invalid-setting',
                     },
                 },
+                'route_object_preference': {
+                    'update_timer': 'not-a-number',
+                },
                 'rpki': {
                     'roa_source': 'https://example.com/roa.json',
                     'roa_import_timer': 'foo',
@@ -303,6 +310,7 @@ class TestConfiguration:
                         'authoritative': True,
                         'import_source': '192.0.2.1',
                         'nrtm_access_list_unfiltered': 'invalid-list',
+                        'route_object_preference': 'not-a-number',
                     },
                     # Not permitted, rpki.roa_source is set
                     'RPKI': {},
@@ -355,6 +363,8 @@ class TestConfiguration:
         assert 'Setting rpki.notify_invalid_header must be a string, if defined.' in str(ce.value)
         assert 'Setting import_timer for source TESTDB must be a number.' in str(ce.value)
         assert 'Setting export_timer for source TESTDB must be a number.' in str(ce.value)
+        assert 'Setting route_object_preference for source TESTDB3 must be a number.' in str(ce.value)
+        assert 'Setting route_object_preference.update_timer must be a number.' in str(ce.value)
         assert 'Setting nrtm_query_serial_range_limit for source TESTDB must be a number.' in str(ce.value)
         assert 'Invalid source name: lowercase' in str(ce.value)
         assert 'Invalid source name: invalid char' in str(ce.value)

--- a/irrd/mirroring/mirror_runners_export.py
+++ b/irrd/mirroring/mirror_runners_export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from irrd.conf import get_setting
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.rpki.status import RPKIStatus
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.storage.database_handler import DatabaseHandler
@@ -70,6 +71,7 @@ class SourceExportRunner:
             query = RPSLDatabaseQuery().sources([self.source])
             query = query.rpki_status([RPKIStatus.not_found, RPKIStatus.valid])
             query = query.scopefilter_status([ScopeFilterStatus.in_scope])
+            query = query.route_preference_status([RoutePreferenceStatus.visible])
             for obj in self.database_handler.execute_query(query):
                 object_text = obj['object_text']
                 if remove_auth_hashes:

--- a/irrd/mirroring/mirror_runners_import.py
+++ b/irrd/mirroring/mirror_runners_import.py
@@ -16,6 +16,7 @@ from irrd.conf.defaults import DEFAULT_SOURCE_NRTM_PORT
 from irrd.rpki.importer import ROADataImporter, ROAParserException
 from irrd.rpki.notifications import notify_rpki_invalid_owners
 from irrd.rpki.validators import BulkRouteROAValidator
+from irrd.routepref.routepref import update_route_preference_status
 from irrd.scopefilter.validators import ScopeFilterValidator
 from irrd.storage.database_handler import DatabaseHandler
 from irrd.storage.event_stream import EventStreamPublisher
@@ -333,6 +334,29 @@ class ScopeFilterUpdateRunner:
             logger.error(f'An exception occurred while attempting a scopefilter status update: {exc}', exc_info=exc)
         finally:
             self.database_handler.close()
+
+
+class RoutePreferenceUpdateRunner:
+    """
+    Update the route preference filter status for all objects.
+    This runner does not actually import anything external, all
+    data is already in our database.
+    """
+    # API consistency with other importers, source is actually ignored
+    def __init__(self, source=None):
+        pass
+
+    def run(self):
+        database_handler = DatabaseHandler()
+
+        try:
+            update_route_preference_status(database_handler)
+            database_handler.commit()
+            logger.info('route preference update commit complete')
+        except Exception as exc:
+            logger.error(f'An exception occurred while attempting a route preference status update: {exc}', exc_info=exc)
+        finally:
+            database_handler.close()
 
 
 class NRTMImportUpdateStreamRunner:

--- a/irrd/mirroring/nrtm_operation.py
+++ b/irrd/mirroring/nrtm_operation.py
@@ -70,7 +70,7 @@ class NRTMOperation:
             return False
 
         if self.operation == DatabaseOperation.add_or_update:
-            if self.rpki_aware and obj.rpki_relevant and obj.prefix and obj.asn_first:
+            if self.rpki_aware and obj.is_route and obj.prefix and obj.asn_first:
                 roa_validator = SingleRouteROAValidator(database_handler)
                 obj.rpki_status = roa_validator.validate_route(obj.prefix, obj.asn_first, obj.source())
             scope_validator = ScopeFilterValidator()
@@ -82,7 +82,7 @@ class NRTMOperation:
                                                 source_serial=self.serial)
 
         log = f'Completed NRTM operation {str(self)}/{obj.rpsl_object_class}/{obj.pk()}'
-        if self.rpki_aware and obj.rpki_relevant:
+        if self.rpki_aware and obj.is_route:
             log += f', RPKI status {obj.rpki_status.value}'
         logger.info(log)
         return True

--- a/irrd/mirroring/parsers.py
+++ b/irrd/mirroring/parsers.py
@@ -108,7 +108,7 @@ class MirrorFileImportParserBase(MirrorParser):
                 self.obj_ignored_class += 1
                 return None
 
-            if self.roa_validator and obj.rpki_relevant and obj.prefix_length and obj.asn_first:
+            if self.roa_validator and obj.is_route and obj.prefix_length and obj.asn_first:
                 obj.rpki_status = self.roa_validator.validate_route(
                     str(obj.ip_first), obj.prefix_length, obj.asn_first, obj.source()
                 )

--- a/irrd/mirroring/tests/test_mirror_runners_export.py
+++ b/irrd/mirroring/tests/test_mirror_runners_export.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from irrd.rpki.status import RPKIStatus
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.utils.test_utils import flatten_mock_calls
 from ..mirror_runners_export import SourceExportRunner, EXPORT_PERMISSIONS
@@ -65,9 +66,11 @@ class TestSourceExportRunner:
             ['sources', (['TEST'],), {}],
             ['rpki_status', ([RPKIStatus.not_found, RPKIStatus.valid],), {}],
             ['scopefilter_status', ([ScopeFilterStatus.in_scope],), {}],
+            ['route_preference_status', ([RoutePreferenceStatus.visible],), {}],
             ['sources', (['TEST'],), {}],
             ['rpki_status', ([RPKIStatus.not_found, RPKIStatus.valid],), {}],
             ['scopefilter_status', ([ScopeFilterStatus.in_scope],), {}],
+            ['route_preference_status', ([RoutePreferenceStatus.visible],), {}],
         ]
         assert 'Starting a source export for TEST' in caplog.text
         assert 'Export for TEST complete' in caplog.text

--- a/irrd/mirroring/tests/test_scheduler.py
+++ b/irrd/mirroring/tests/test_scheduler.py
@@ -177,6 +177,29 @@ class TestMirrorScheduler:
         time.sleep(0.2)
         assert thread_run_count == 3
 
+    def test_scheduler_runs_route_preference(self, monkeypatch, config_override):
+        monkeypatch.setattr('irrd.mirroring.scheduler.ScheduledTaskProcess', MockScheduledTaskProcess)
+        global thread_run_count
+        thread_run_count = 0
+
+        config_override({
+            'rpki': {'roa_source': None},
+            'sources': {
+                'TEST': {"route_object_preference": 200},
+            }
+        })
+
+        monkeypatch.setattr('irrd.mirroring.scheduler.RoutePreferenceUpdateRunner', MockRunner)
+        MockRunner.run_sleep = True
+
+        scheduler = MirrorScheduler()
+        scheduler.run()
+        # Second run will not start the thread, as the current one is still running
+        time.sleep(0.5)
+        scheduler.run()
+
+        assert thread_run_count == 1
+
     def test_scheduler_import_ignores_timer_not_expired(self, monkeypatch, config_override):
         monkeypatch.setattr('irrd.mirroring.scheduler.ScheduledTaskProcess', MockScheduledTaskProcess)
         global thread_run_count
@@ -270,7 +293,7 @@ class MockRunner:
     run_sleep = True
 
     def __init__(self, source):
-        assert source in ['TEST', 'TEST2', 'TEST3', 'TEST4', 'RPKI', 'scopefilter']
+        assert source in ['TEST', 'TEST2', 'TEST3', 'TEST4', 'RPKI', 'scopefilter', 'routepref']
 
     def run(self):
         global thread_run_count

--- a/irrd/routepref/routepref.py
+++ b/irrd/routepref/routepref.py
@@ -59,19 +59,6 @@ class RoutePreferenceValidator:
                 rnode.data = {}
             rnode.data[route_object["pk"]] = (preference, route_object["route_preference_status"])
 
-    def validate_single(self, prefix: IP, source: str) -> RoutePreferenceStatus:
-        # TODO: we might not need this at all?
-        if not self.source_preferences:
-            return RoutePreferenceStatus.visible
-        try:
-            preference = self.source_preferences[source]
-        except KeyError:
-            return RoutePreferenceStatus.visible
-
-        search_args = {"network": str(prefix)}
-        overlapping_nodes = self.rtree.search_covered(**search_args) + self.rtree.search_covering(**search_args)
-        return self._evaluate_route(preference, overlapping_nodes)
-
     def validate_known_routes(self) -> Tuple[List[str], List[str]]:
         """
         Validate all routes known to this validator, based on the

--- a/irrd/routepref/routepref.py
+++ b/irrd/routepref/routepref.py
@@ -1,0 +1,190 @@
+import logging
+from typing import List, Dict, Iterable, Tuple, Optional
+
+import radix
+from IPy import IP
+from radix.radix import RadixNode
+
+from irrd.conf import get_setting
+from irrd.storage.database_handler import DatabaseHandler
+from irrd.storage.queries import RPSLDatabaseQuery
+from .status import RoutePreferenceStatus
+
+
+logger = logging.getLogger(__name__)
+
+
+class RoutePreferenceValidator:
+    """
+    The route preference validator determines which route objects
+    need their state updated. It operates on an iterable of objects,
+    which may be all objects in the database, or a subset for certain
+    prefixes. Based on the current preference setting, the validator
+    determines new states based on the given set of routes, which
+    means for, e.g. a change to a few route objects, you must pass
+    the changed objects and any overlapping route objects.
+    """
+
+    def __init__(self, existing_route_objects: Iterable[Dict[str, str]]):
+        """
+        Initialise the validator with an iterable of route objects as dicts.
+        The route object dict must have prefix, source, pk and route_preference_status columns.
+        """
+        self.source_preferences = {
+            source_name: int(source_data.get("route_object_preference"))
+            for source_name, source_data in get_setting("sources", {}).items()
+            if source_data.get("route_object_preference") is not None
+        }
+        self.max_preference = max(self.source_preferences.values()) if self.source_preferences else None
+
+        self.rtree = radix.Radix()
+        self.excluded_currently_suppressed: List[str] = []
+        self._build_tree(existing_route_objects)
+
+    def _build_tree(self, route_objects: Iterable[Dict[str, str]]) -> None:
+        """
+        Build the tree of route objects and their preferences.
+        Also sets self.excluded_currently_suppressed as a side effect.
+        """
+        for route_object in route_objects:
+            try:
+                preference = self.source_preferences[route_object["source"]]
+            except KeyError:
+                if route_object["route_preference_status"] != RoutePreferenceStatus.visible:
+                    self.excluded_currently_suppressed.append(route_object["pk"])
+                continue
+
+            rnode = self.rtree.add(route_object["prefix"])
+            if not rnode.data:
+                rnode.data = {}
+            rnode.data[route_object["pk"]] = (preference, route_object["route_preference_status"])
+
+    def validate_single(self, prefix: IP, source: str) -> RoutePreferenceStatus:
+        # TODO: we might not need this at all?
+        if not self.source_preferences:
+            return RoutePreferenceStatus.visible
+        try:
+            preference = self.source_preferences[source]
+        except KeyError:
+            return RoutePreferenceStatus.visible
+
+        search_args = {"network": str(prefix)}
+        overlapping_nodes = self.rtree.search_covered(**search_args) + self.rtree.search_covering(**search_args)
+        return self._evaluate_route(preference, overlapping_nodes)
+
+    def validate_known_routes(self) -> Tuple[List[str], List[str]]:
+        """
+        Validate all routes known to this validator, based on the
+        previously built tree. Returns a tuple of two lists:
+        pks of "currently suppressed, should be visible" and vice versa.
+        """
+        if not self.source_preferences:
+            # All objects should be visible if there is no setting,
+            # which in that case is caught in self.excluded_currently_suppressed
+            # by _build_tree, meaning there is no action here.
+            return [], []
+        to_be_visible = []
+        to_be_suppressed = []
+        for evaluated_node in self.rtree:
+            search_args = {"packed": evaluated_node.packed, "masklen": evaluated_node.prefixlen}
+            overlapping_nodes = self.rtree.search_covered(**search_args) + self.rtree.search_covering(**search_args)
+
+            for evaluated_key, (evaluated_preference, current_status) in evaluated_node.data.items():
+                new_status = self._evaluate_route(evaluated_preference, overlapping_nodes)
+                if new_status != current_status:
+                    if new_status == RoutePreferenceStatus.suppressed:
+                        to_be_suppressed.append(evaluated_key)
+                    elif new_status == RoutePreferenceStatus.visible:
+                        to_be_visible.append(evaluated_key)
+        return to_be_visible, to_be_suppressed
+
+    def _evaluate_route(self, route_preference: int, overlapping_nodes: List[RadixNode]) -> RoutePreferenceStatus:
+        """
+        Given a preference, evaluate the correct state of a route based
+        on a given list of overlapping nodes.
+        """
+        if route_preference == self.max_preference:
+            return RoutePreferenceStatus.visible
+
+        for overlapping_node in overlapping_nodes:
+            for overlapping_preference, _ in overlapping_node.data.values():
+                if overlapping_preference > route_preference:
+                    return RoutePreferenceStatus.suppressed
+        return RoutePreferenceStatus.visible
+
+
+def build_validator(
+    database_handler: DatabaseHandler, filter_prefixes: Optional[Iterable[IP]] = None
+) -> RoutePreferenceValidator:
+    """
+    Build a RouteValidator instance given a database handler
+    and an optional set of prefixes to limit the query.
+    """
+    columns = ["prefix", "source", "pk", "route_preference_status"]
+    object_classes = ["route", "route6"]
+
+    if not filter_prefixes:
+        q = RPSLDatabaseQuery(column_names=columns, ordered_by_sources=False).object_classes(object_classes)
+        return RoutePreferenceValidator(database_handler.execute_query(q))
+    else:
+        rows = []
+        for filter_prefix in filter_prefixes:
+            q = (
+                RPSLDatabaseQuery(column_names=columns, ordered_by_sources=False)
+                .object_classes(object_classes)
+                .ip_any(filter_prefix)
+            )
+            rows += list(database_handler.execute_query(q))
+        return RoutePreferenceValidator(rows)
+
+
+def update_route_preference_status(
+    database_handler: DatabaseHandler, filter_prefixes: Optional[List[IP]] = None
+) -> None:
+    """
+    Update the route preference status, given a database handler
+    and an optional set of prefixes to limit the evaluation.
+    Results are saved to the database and counters are logged.
+    """
+    validator = build_validator(database_handler, filter_prefixes)
+    pks_to_be_visible, pks_to_be_suppressed = validator.validate_known_routes()
+    pks_to_become_visible = pks_to_be_visible + validator.excluded_currently_suppressed
+
+    objs_to_become_visible = enrich_pks(database_handler, pks_to_become_visible)
+    objs_to_be_suppressed = enrich_pks(database_handler, pks_to_be_suppressed)
+    database_handler.update_route_preference_status(objs_to_become_visible, objs_to_be_suppressed)
+
+    common_log = (
+        f"{len(pks_to_be_visible)} regular objects made visible, "
+        f"{len(pks_to_be_suppressed)} regular objects suppressed, "
+        f"{len(validator.excluded_currently_suppressed)} objects from excluded sources made visible"
+    )
+    if not filter_prefixes:
+        logger.info(f"route preference updated for all routes: {common_log}")
+    else:
+        logger.info(
+            f"route preference updated for a subset of {len(filter_prefixes)} added/removed/changed routes:"
+            f" {common_log}"
+        )
+
+
+def enrich_pks(database_handler: DatabaseHandler, pks_to_enrich: List[str]):
+    """
+    Enrich objects based on a set of row PKs.
+    This is used for early retrieval of a subset of columns to analyse,
+    then enrich the data that needs its state changed, which requires
+    journal entries with additional columns.
+    """
+    columns = [
+        "pk",
+        "object_text",
+        "rpsl_pk",
+        "source",
+        "prefix",
+        "origin",
+        "object_class",
+        "scopefilter_status",
+        "rpki_status",
+    ]
+    query = RPSLDatabaseQuery(columns, enable_ordering=False).pks(pks_to_enrich)
+    return database_handler.execute_query(query)

--- a/irrd/routepref/status.py
+++ b/irrd/routepref/status.py
@@ -1,0 +1,11 @@
+import enum
+
+
+@enum.unique
+class RoutePreferenceStatus(enum.Enum):
+    visible = "VISIBLE"
+    suppressed = "SUPPRESSED"
+
+    @classmethod
+    def is_visible(cls, status: "RoutePreferenceStatus"):
+        return status == cls.visible

--- a/irrd/routepref/tests/test_routepref.py
+++ b/irrd/routepref/tests/test_routepref.py
@@ -66,20 +66,20 @@ def test_route_preference_validator(config_override):
             "pk": "route-H",
             "route_preference_status": RoutePreferenceStatus.visible,
         },
+        {
+            # No overlaps
+            "source": "SRC-LOWEST",
+            "prefix": "198.51.100.0/24",
+            "pk": "route-I",
+            "route_preference_status": RoutePreferenceStatus.suppressed,
+        },
     ]
 
     validator = RoutePreferenceValidator(route_objects)
     to_be_visible, to_be_suppressed = validator.validate_known_routes()
     assert validator.excluded_currently_suppressed == ["route-G"]
-    assert to_be_visible == ["route-A", "route-B"]
+    assert to_be_visible == ["route-A", "route-B", "route-I"]
     assert to_be_suppressed == ["route-D", "route-C", "route-E", "route-F"]
-
-    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-NOPREF") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-LOWEST") == RoutePreferenceStatus.suppressed
-    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.suppressed
-    assert validator.validate_single(IP("191.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.visible
 
     config_override(
         {
@@ -94,15 +94,8 @@ def test_route_preference_validator(config_override):
 
     validator = RoutePreferenceValidator(route_objects)
     to_be_visible, to_be_suppressed = validator.validate_known_routes()
-    assert validator.excluded_currently_suppressed == ["route-A", "route-B", "route-G"]
+    assert validator.excluded_currently_suppressed == ["route-A", "route-B", "route-G", "route-I"]
     assert to_be_suppressed == []
-
-    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-NOPREF") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-LOWEST") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.visible
-    assert validator.validate_single(IP("191.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.visible
 
 
 def test_update_route_preference_status(config_override):

--- a/irrd/routepref/tests/test_routepref.py
+++ b/irrd/routepref/tests/test_routepref.py
@@ -1,0 +1,195 @@
+from IPy import IP
+
+from irrd.storage.queries import RPSLDatabaseQuery
+from irrd.utils.test_utils import MockDatabaseHandler
+from ..routepref import RoutePreferenceValidator, update_route_preference_status
+from ..status import RoutePreferenceStatus
+
+
+def test_route_preference_validator(config_override):
+    config_override(
+        {
+            "sources": {
+                "SRC-HIGH-A": {"route_object_preference": 900},
+                "SRC-HIGH-B": {"route_object_preference": 900},
+                "SRC-LOWEST": {"route_object_preference": 100},
+                "SRC-LOW": {"route_object_preference": 200},
+            }
+        }
+    )
+    route_objects = [
+        {
+            "source": "SRC-HIGH-A",
+            "prefix": "192.0.0.0/23",
+            "pk": "route-A",
+            "route_preference_status": RoutePreferenceStatus.suppressed,
+        },
+        {
+            "source": "SRC-HIGH-B",
+            "prefix": "192.0.0.0/24",
+            "pk": "route-B",
+            "route_preference_status": RoutePreferenceStatus.suppressed,
+        },
+        {
+            "source": "SRC-LOWEST",
+            "prefix": "192.0.0.0/23",
+            "pk": "route-C",
+            "route_preference_status": RoutePreferenceStatus.visible,
+        },
+        {
+            "source": "SRC-LOW",
+            "prefix": "192.0.0.0/22",
+            "pk": "route-D",
+            "route_preference_status": RoutePreferenceStatus.visible,
+        },
+        {
+            "source": "SRC-LOW",
+            "prefix": "192.0.1.0/24",
+            "pk": "route-E",
+            "route_preference_status": RoutePreferenceStatus.visible,
+        },
+        {
+            "source": "SRC-LOWEST",
+            "prefix": "192.0.3.0/24",
+            "pk": "route-F",
+            "route_preference_status": RoutePreferenceStatus.visible,
+        },
+        {
+            "source": "SRC-NOPREF",
+            "prefix": "192.0.0.0/24",
+            "pk": "route-G",
+            "route_preference_status": RoutePreferenceStatus.suppressed,
+        },
+        {
+            "source": "SRC-NOPREF",
+            "prefix": "192.0.0.0/32",
+            "pk": "route-H",
+            "route_preference_status": RoutePreferenceStatus.visible,
+        },
+    ]
+
+    validator = RoutePreferenceValidator(route_objects)
+    to_be_visible, to_be_suppressed = validator.validate_known_routes()
+    assert validator.excluded_currently_suppressed == ["route-G"]
+    assert to_be_visible == ["route-A", "route-B"]
+    assert to_be_suppressed == ["route-D", "route-C", "route-E", "route-F"]
+
+    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-NOPREF") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-LOWEST") == RoutePreferenceStatus.suppressed
+    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.suppressed
+    assert validator.validate_single(IP("191.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.visible
+
+    config_override(
+        {
+            "sources": {
+                "SRC-HIGH-A": {},
+                "SRC-HIGH-B": {},
+                "SRC-LOWEST": {},
+                "SRC-LOW": {},
+            }
+        }
+    )
+
+    validator = RoutePreferenceValidator(route_objects)
+    to_be_visible, to_be_suppressed = validator.validate_known_routes()
+    assert validator.excluded_currently_suppressed == ["route-A", "route-B", "route-G"]
+    assert to_be_suppressed == []
+
+    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-NOPREF") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/26"), "SRC-LOWEST") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-HIGH-A") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("192.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.visible
+    assert validator.validate_single(IP("191.0.0.0/8"), "SRC-LOWEST") == RoutePreferenceStatus.visible
+
+
+def test_update_route_preference_status(config_override):
+    config_override(
+        {
+            "sources": {
+                "SRC-HIGH": {"route_object_preference": 900},
+                "SRC-LOW": {"route_object_preference": 200},
+            }
+        }
+    )
+    route_objects = [
+        {
+            "source": "SRC-HIGH",
+            "prefix": "192.0.0.0/23",
+            "pk": "route-A",
+            "route_preference_status": RoutePreferenceStatus.suppressed,
+        },
+        {
+            "source": "SRC-LOW",
+            "prefix": "192.0.0.0/22",
+            "pk": "route-D",
+            "route_preference_status": RoutePreferenceStatus.visible,
+        },
+    ]
+
+    object_classes = ["route", "route6"]
+    expected_columns = ["prefix", "source", "pk", "route_preference_status"]
+    enrich_columns = [
+        "pk",
+        "object_text",
+        "rpsl_pk",
+        "source",
+        "prefix",
+        "origin",
+        "object_class",
+        "object_text",
+        "scopefilter_status",
+        "rpki_status",
+    ]
+
+    # First, test without a filter for specific prefixes.
+    mock_dh = MockDatabaseHandler()
+    mock_dh.reset_mock()
+    mock_dh.query_responses[RPSLDatabaseQuery] = iter(route_objects)
+    update_route_preference_status(mock_dh)
+    assert mock_dh.queries == [
+        RPSLDatabaseQuery(column_names=expected_columns, ordered_by_sources=False).object_classes(object_classes),
+        RPSLDatabaseQuery(
+            enrich_columns,
+            enable_ordering=False,
+        ).pks(["route-A"]),
+        RPSLDatabaseQuery(
+            enrich_columns,
+            enable_ordering=False,
+        ).pks(["route-D"]),
+    ]
+    assert mock_dh.other_calls == [
+        (
+            "update_route_preference_status",
+            {"rpsl_objs_now_visible": [], "rpsl_objs_now_suppressed": []},
+        )
+    ]
+
+    # Second, test with a filter for specific prefixes
+    mock_dh.reset_mock()
+    mock_dh.query_responses[RPSLDatabaseQuery] = iter(route_objects)
+    update_route_preference_status(mock_dh, [IP("192.0.0.0/23"), IP("198.51.100.0/24")])
+    assert mock_dh.queries == [
+        RPSLDatabaseQuery(column_names=expected_columns, ordered_by_sources=False)
+        .object_classes(object_classes)
+        .ip_any(IP("192.0.0.0/23")),
+        RPSLDatabaseQuery(column_names=expected_columns, ordered_by_sources=False)
+        .object_classes(object_classes)
+        .ip_any(IP("198.51.100.0/24")),
+        RPSLDatabaseQuery(
+            enrich_columns,
+            enable_ordering=False,
+        ).pks(["route-A"]),
+        RPSLDatabaseQuery(
+            enrich_columns,
+            enable_ordering=False,
+        ).pks(["route-D"]),
+    ]
+    assert mock_dh.other_calls == [
+        (
+            "update_route_preference_status",
+            {"rpsl_objs_now_visible": [], "rpsl_objs_now_suppressed": []},
+        )
+    ]

--- a/irrd/rpki/status.py
+++ b/irrd/rpki/status.py
@@ -1,7 +1,12 @@
 import enum
 
 
+@enum.unique
 class RPKIStatus(enum.Enum):
     valid = 'VALID'
     invalid = 'INVALID'
     not_found = 'NOT_FOUND'
+
+    @classmethod
+    def is_visible(cls, status: "RPKIStatus"):
+        return status in (cls.valid, cls.not_found)

--- a/irrd/rpki/validators.py
+++ b/irrd/rpki/validators.py
@@ -86,7 +86,7 @@ class BulkRouteROAValidator:
         validation result, are not included in the return value.
         """
         columns = ['pk', 'rpsl_pk', 'ip_first', 'prefix_length', 'asn_first', 'source',
-                   'rpki_status', 'scopefilter_status']
+                   'rpki_status']
         q = RPSLDatabaseQuery(column_names=columns, enable_ordering=False)
         q = q.object_classes(['route', 'route6'])
         if sources:
@@ -110,7 +110,7 @@ class BulkRouteROAValidator:
 
         # Object text and class are only retrieved for objects with state changes
         pks_to_enrich = [obj['pk'] for objs in objs_changed.values() for obj in objs]
-        query = RPSLDatabaseQuery(['pk', 'object_text', 'object_class'], enable_ordering=False).pks(pks_to_enrich)
+        query = RPSLDatabaseQuery(['pk', 'prefix', 'object_text', 'object_class', 'scopefilter_status', 'route_preference_status'], enable_ordering=False).pks(pks_to_enrich)
         rows_per_pk = {row['pk']: row for row in self.database_handler.execute_query(query)}
 
         for rpsl_objs in objs_changed.values():

--- a/irrd/rpsl/parser.py
+++ b/irrd/rpsl/parser.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple, Any, Set
 from IPy import IP
 
 from irrd.rpki.status import RPKIStatus
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.rpsl.parser_state import RPSLParserMessages
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.utils.text import splitline_unicodesafe
@@ -68,11 +69,12 @@ class RPSLObject(metaclass=RPSLObjectMeta):
     prefix_length: Optional[int] = None
     rpki_status: RPKIStatus = RPKIStatus.not_found
     scopefilter_status: ScopeFilterStatus = ScopeFilterStatus.in_scope
+    route_preference_status: RoutePreferenceStatus = RoutePreferenceStatus.visible
     pk_asn_segment: Optional[str] = None
     default_source: Optional[str] = None  # noqa: E704 (flake8 bug)
-    # Whether this object has a relation to RPKI ROA data, and therefore RPKI
-    # checks should be performed in certain scenarios. Enabled for route/route6.
-    rpki_relevant = False
+    # Shortcut for whether this object is a route-like object, and therefore
+    # should be included in RPKI and route preference status. Enabled for route/route6.
+    is_route = False
     # Fields whose values are discarded during parsing
     discarded_fields: List[str] = []
     # Fields that are ignored in validation even

--- a/irrd/rpsl/rpsl_objects.py
+++ b/irrd/rpsl/rpsl_objects.py
@@ -414,7 +414,7 @@ class RPSLRole(RPSLObject):
 
 
 class RPSLRoute(RPSLObject):
-    rpki_relevant = True
+    is_route = True
     discarded_fields = ['rpki-ov-state']
     fields = OrderedDict([
         ('route', RPSLIPv4PrefixField(primary_key=True, lookup_key=True)),
@@ -457,7 +457,7 @@ class RPSLRouteSet(RPSLSet):
 
 
 class RPSLRoute6(RPSLObject):
-    rpki_relevant = True
+    is_route = True
     discarded_fields = ['rpki-ov-state']
     fields = OrderedDict([
         ('route6', RPSLIPv6PrefixField(primary_key=True, lookup_key=True)),
@@ -522,7 +522,7 @@ OBJECT_CLASS_MAPPING = {
 RPKI_RELEVANT_OBJECT_CLASSES = [
     rpsl_object.rpsl_object_class
     for rpsl_object in OBJECT_CLASS_MAPPING.values()
-    if rpsl_object.rpki_relevant
+    if rpsl_object.is_route
 ]
 
 

--- a/irrd/scopefilter/status.py
+++ b/irrd/scopefilter/status.py
@@ -1,7 +1,12 @@
 import enum
 
 
+@enum.unique
 class ScopeFilterStatus(enum.Enum):
     in_scope = 'IN_SCOPE'
     out_scope_as = 'OUT_SCOPE_AS'
     out_scope_prefix = 'OUT_SCOPE_PREFIX'
+
+    @classmethod
+    def is_visible(cls, status: "ScopeFilterStatus"):
+        return status == cls.in_scope

--- a/irrd/scopefilter/validators.py
+++ b/irrd/scopefilter/validators.py
@@ -113,7 +113,7 @@ class ScopeFilterValidator:
         validation result, are not included in the return value.
         """
         columns = ['pk', 'rpsl_pk', 'prefix', 'asn_first', 'source', 'object_class',
-                   'scopefilter_status', 'rpki_status']
+                   'scopefilter_status']
 
         objs_changed: Dict[ScopeFilterStatus, List[Dict[str, str]]] = defaultdict(list)
 
@@ -139,7 +139,7 @@ class ScopeFilterValidator:
 
         # Object text is only retrieved for objects with state changes
         pks_to_enrich = [obj['pk'] for objs in objs_changed.values() for obj in objs]
-        query = RPSLDatabaseQuery(['pk', 'object_text'], enable_ordering=False).pks(pks_to_enrich)
+        query = RPSLDatabaseQuery(['pk', 'object_text', 'rpki_status', 'route_preference_status'], enable_ordering=False).pks(pks_to_enrich)
         rows_per_pk = {row['pk']: row for row in database_handler.execute_query(query)}
 
         for rpsl_objs in objs_changed.values():

--- a/irrd/server/graphql/tests/test_resolvers.py
+++ b/irrd/server/graphql/tests/test_resolvers.py
@@ -5,6 +5,7 @@ from IPy import IP
 from graphql import GraphQLError
 from starlette.requests import HTTPConnection
 
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.rpki.status import RPKIStatus
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.server.query_resolver import QueryResolver
@@ -22,6 +23,7 @@ EXPECTED_RPSL_GRAPHQL_OUTPUT = [{
     'operation': DatabaseOperation.add_or_update,
     'rpkiStatus': RPKIStatus.not_found,
     'scopefilterStatus': ScopeFilterStatus.out_scope_as,
+    'routePreferenceStatus': RoutePreferenceStatus.suppressed,
     'source': 'TEST1',
     'route': '192.0.2.0/25',
     'origin': 'AS65547',
@@ -51,6 +53,7 @@ MOCK_RPSL_DB_RESULT = [{
     'object_text': 'object text\nauth: CRYPT-PW LEuuhsBJNFV0Q',
     'rpki_status': RPKIStatus.not_found,
     'scopefilter_status': ScopeFilterStatus.out_scope_as,
+    'route_preference_status': RoutePreferenceStatus.suppressed,
     'source': 'TEST1',
     # only used in journal test
     'operation': DatabaseOperation.add_or_update,
@@ -116,6 +119,7 @@ class TestGraphQLResolvers:
             text_search='text',
             rpki_status=[RPKIStatus.invalid],
             scope_filter_status=[ScopeFilterStatus.out_scope_as],
+            route_preference_status=[RoutePreferenceStatus.suppressed],
             ip_exact='192.0.2.1',
             sources=['TEST1'],
             mntBy='mnt-by',
@@ -132,6 +136,7 @@ class TestGraphQLResolvers:
             ['text_search', ('text',), {}],
             ['rpki_status', ([RPKIStatus.invalid],), {}],
             ['scopefilter_status', ([ScopeFilterStatus.out_scope_as],), {}],
+            ['route_preference_status', ([RoutePreferenceStatus.suppressed],), {}],
             ['sources', (['TEST1'],), {}],
             ['lookup_attrs_in', (['mnt-by'], 'mnt-by'), {}],
             ['ip_exact', (IP('192.0.2.1'),), {}],
@@ -151,6 +156,7 @@ class TestGraphQLResolvers:
             ['rpsl_pks', ('pk',), {}],
             ['rpki_status', ([RPKIStatus.not_found, RPKIStatus.valid],), {}],
             ['scopefilter_status', ([ScopeFilterStatus.in_scope],), {}],
+            ['route_preference_status', ([RoutePreferenceStatus.visible],), {}],
             ['sources', (['TEST1'],), {}],
         ]
 

--- a/irrd/server/graphql/tests/test_schema_generator.py
+++ b/irrd/server/graphql/tests/test_schema_generator.py
@@ -19,6 +19,11 @@ enum ScopeFilterStatus {
     out_scope_prefix
 }
 
+enum RoutePreferenceStatus {
+    visible
+    suppressed
+}
+
 
             scalar ASN
             scalar IP
@@ -28,7 +33,7 @@ enum ScopeFilterStatus {
             }
 
             type Query {
-              rpslObjects(adminC: [String!], mbrsByRef: [String!], memberOf: [String!], members: [String!], mntBy: [String!], mpMembers: [String!], objectClass: [String!], origin: [String!], person: [String!], role: [String!], rpslPk: [String!], sources: [String!], techC: [String!], zoneC: [String!], ipExact: IP, ipLessSpecific: IP, ipLessSpecificOneLevel: IP, ipMoreSpecific: IP, ipAny: IP, asn: [ASN!], rpkiStatus: [RPKIStatus!], scopeFilterStatus: [ScopeFilterStatus!], textSearch: String, recordLimit: Int, sqlTrace: Boolean): [RPSLObject!]
+              rpslObjects(adminC: [String!], mbrsByRef: [String!], memberOf: [String!], members: [String!], mntBy: [String!], mpMembers: [String!], objectClass: [String!], origin: [String!], person: [String!], role: [String!], rpslPk: [String!], sources: [String!], techC: [String!], zoneC: [String!], ipExact: IP, ipLessSpecific: IP, ipLessSpecificOneLevel: IP, ipMoreSpecific: IP, ipAny: IP, asn: [ASN!], rpkiStatus: [RPKIStatus!], scopeFilterStatus: [ScopeFilterStatus!], routePreferenceStatus: [RoutePreferenceStatus!], textSearch: String, recordLimit: Int, sqlTrace: Boolean): [RPSLObject!]
               databaseStatus(sources: [String!]): [DatabaseStatus]
               asnPrefixes(asns: [ASN!]!, ipVersion: Int, sources: [String!]): [ASNPrefixes!]
               asSetPrefixes(setNames: [String!]!, ipVersion: Int, sources: [String!], excludeSets: [String!], sqlTrace: Boolean): [AsSetPrefixes!]
@@ -41,6 +46,7 @@ enum ScopeFilterStatus {
                 objectClassFilter: [String!]
                 rpkiRovFilter: Boolean!
                 scopefilterEnabled: Boolean!
+                routePreference: Int
                 localJournalKept: Boolean!
                 serialOldestJournal: Int
                 serialNewestJournal: Int
@@ -469,6 +475,7 @@ type RPSLRoute implements RPSLObject {
   asn: ASN
   rpkiStatus: RPKIStatus
   rpkiMaxLength: Int
+  routePreferenceStatus: RoutePreferenceStatus
 }
 
 type RPSLRouteSet implements RPSLObject {
@@ -531,6 +538,7 @@ type RPSLRoute6 implements RPSLObject {
   asn: ASN
   rpkiStatus: RPKIStatus
   rpkiMaxLength: Int
+  routePreferenceStatus: RoutePreferenceStatus
 }
 
 type RPSLRtrSet implements RPSLObject {

--- a/irrd/server/http/event_stream.py
+++ b/irrd/server/http/event_stream.py
@@ -19,6 +19,7 @@ from typing_extensions import Literal
 from irrd.conf import get_setting
 from irrd.rpki.status import RPKIStatus
 from irrd.rpsl.rpsl_objects import rpsl_object_from_text
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.server.access_check import is_client_permitted
 from irrd.storage.database_handler import DatabaseHandler
@@ -113,6 +114,7 @@ class EventStreamInitialDownloadGenerator:
             )
             .rpki_status([RPKIStatus.not_found.name, RPKIStatus.valid.name])
             .scopefilter_status([ScopeFilterStatus.in_scope.name])
+            .route_preference_status([RoutePreferenceStatus.visible.name])
         )
         if self.sources:
             query = query.sources(self.sources)

--- a/irrd/server/http/status_generator.py
+++ b/irrd/server/http/status_generator.py
@@ -108,6 +108,7 @@ class StatusGenerator:
             scopefilter_enabled = get_setting('scopefilter') and not get_setting(f'sources.{source}.scopefilter_excluded')
             scopefilter_enabled_str = 'Yes' if scopefilter_enabled else 'No'
             synchronised_serials_str = 'Yes' if is_serial_synchronised(database_handler, source) else 'No'
+            route_object_preference = get_setting(f'sources.{source}.route_object_preference')
 
             nrtm_host = get_setting(f'sources.{source}.nrtm_host')
             nrtm_port = int(get_setting(f'sources.{source}.nrtm_port', DEFAULT_SOURCE_NRTM_PORT))
@@ -133,6 +134,7 @@ class StatusGenerator:
                 Last import error occurred at: {status_result['last_error_timestamp']}
                 RPKI validation enabled: {rpki_enabled_str}
                 Scope filter enabled: {scopefilter_enabled_str}
+                Route object preference: {route_object_preference}
 
             Remote information:{remote_information}
             """)

--- a/irrd/server/http/tests/test_status_generator.py
+++ b/irrd/server/http/tests/test_status_generator.py
@@ -48,6 +48,7 @@ class TestStatusGenerator:
                     'nrtm_port': 43,
                     'object_class_filter': 'object-class-filter',
                     'rpki_excluded': True,
+                    'route_object_preference': 200,
                 },
                 'TEST2': {
                     'authoritative': True,
@@ -157,6 +158,7 @@ class TestStatusGenerator:
                 Last import error occurred at: 2018-01-01 00:00:00+00:00
                 RPKI validation enabled: No
                 Scope filter enabled: No
+                Route object preference: 200
             
             Remote information:
                 NRTM host: nrtm1.example.com port 43
@@ -183,7 +185,8 @@ class TestStatusGenerator:
                 Last import error occurred at: 2019-01-01 00:00:00+00:00
                 RPKI validation enabled: Yes
                 Scope filter enabled: No
-            
+                Route object preference: None
+
             Remote information:
                 NRTM host: nrtm2.example.com port 44
                 Remote status query unsupported or query failed
@@ -206,6 +209,7 @@ class TestStatusGenerator:
                 Last import error occurred at: None
                 RPKI validation enabled: Yes
                 Scope filter enabled: No
+                Route object preference: None
             
             Remote information:
                 NRTM host: nrtm3.example.com port 45
@@ -229,6 +233,7 @@ class TestStatusGenerator:
                 Last import error occurred at: None
                 RPKI validation enabled: Yes
                 Scope filter enabled: No
+                Route object preference: None
             
             Remote information:
                 No NRTM host configured.\n\n""").lstrip()

--- a/irrd/server/whois/query_parser.py
+++ b/irrd/server/whois/query_parser.py
@@ -123,6 +123,10 @@ class WhoisQueryParser:
             self.query_resolver.disable_out_of_scope_filter()
             result = 'Filtering out out-of-scope objects is disabled for !r and RIPE style ' \
                      'queries for the rest of this connection.'
+        elif full_command.upper() == 'FNO-ROUTE-PREFERENCE-FILTER':
+            self.query_resolver.disable_route_preference_filter()
+            result = 'Filtering out objects suppressed due to route preference is disabled for ' \
+                     '!r and RIPE style queries for the rest of this connection.'
         elif command == 'v':
             result = self.handle_irrd_version()
         elif command == 't':

--- a/irrd/server/whois/tests/test_query_parser.py
+++ b/irrd/server/whois/tests/test_query_parser.py
@@ -828,6 +828,13 @@ class TestWhoisQueryParserIRRD:
         assert response.result.startswith('Filtering out out-of-scope')
         mock_query_resolver.disable_out_of_scope_filter.assert_called_once_with()
 
+        mock_query_resolver.disable_route_preference_filter = Mock()
+        response = parser.handle_query('!fno-route-preference-filter')
+        assert response.response_type == WhoisQueryResponseType.SUCCESS
+        assert response.mode == WhoisQueryResponseMode.IRRD
+        assert response.result.startswith('Filtering out objects suppressed due to route')
+        mock_query_resolver.disable_route_preference_filter.assert_called_once_with()
+
     def test_exception_handling(self, prepare_parser, caplog):
         mock_query_resolver, mock_dh, parser = prepare_parser
         mock_query_resolver.members_for_set = Mock(side_effect=Exception('test-error'))

--- a/irrd/storage/alembic/versions/fd4473bc1a10_add_route_preference_status.py
+++ b/irrd/storage/alembic/versions/fd4473bc1a10_add_route_preference_status.py
@@ -1,0 +1,54 @@
+"""add_route_preference_status
+
+Revision ID: fd4473bc1a10
+Revises: 8b8357acd333
+Create Date: 2022-12-24 16:25:59.648631
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.exc import ProgrammingError
+
+# revision identifiers, used by Alembic.
+revision = "fd4473bc1a10"
+down_revision = "8b8357acd333"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    route_preference_status = sa.Enum("visible", "suppressed", name="routepreferencestatus")
+    route_preference_status.create(op.get_bind())
+
+    op.add_column(
+        "rpsl_objects",
+        sa.Column(
+            "route_preference_status",
+            sa.Enum("visible", "suppressed", name="routepreferencestatus"),
+            server_default="visible",
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        op.f("ix_rpsl_objects_route_preference_status"),
+        "rpsl_objects",
+        ["route_preference_status"],
+        unique=False,
+    )
+
+    # downgrade() can't remove this entry from the enum, so if this migration
+    # is reverted and then re-applied, altering the enum will fail
+    with op.get_context().autocommit_block():
+        try:
+            op.execute("ALTER TYPE journalentryorigin ADD VALUE 'route_preference'")
+        except ProgrammingError as pe:
+            if "DuplicateObject" not in str(pe):
+                raise pe
+
+
+def downgrade():
+    op.drop_index(op.f("ix_rpsl_objects_route_preference_status"), table_name="rpsl_objects")
+    op.drop_column("rpsl_objects", "route_preference_status")
+
+    route_preference_status = sa.Enum("visible", "suppressed", name="routepreferencestatus")
+    route_preference_status.drop(op.get_bind())

--- a/irrd/storage/models.py
+++ b/irrd/storage/models.py
@@ -4,6 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.rpki.status import RPKIStatus
 from irrd.rpsl.rpsl_objects import lookup_field_names
 from irrd.scopefilter.status import ScopeFilterStatus
@@ -31,6 +32,8 @@ class JournalEntryOrigin(enum.Enum):
     scope_filter = 'SCOPE_FILTER'
     # Journal entry caused by an object being suspended or reactivated
     suspension = 'SUSPENSION'
+    # Journal entry caused by an object's route preference changing between suppressed and visible
+    route_preference = 'ROUTE_PREFERENCE'
 
 
 Base = declarative_base()
@@ -68,6 +71,7 @@ class RPSLDatabaseObject(Base):  # type: ignore
 
     rpki_status = sa.Column(sa.Enum(RPKIStatus), nullable=False, index=True, server_default=RPKIStatus.not_found.name)
     scopefilter_status = sa.Column(sa.Enum(ScopeFilterStatus), nullable=False, index=True, server_default=ScopeFilterStatus.in_scope.name)
+    route_preference_status = sa.Column(sa.Enum(RoutePreferenceStatus), nullable=False, index=True, server_default=RoutePreferenceStatus.visible.name)
 
     created = sa.Column(sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False)
     updated = sa.Column(sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False)

--- a/irrd/storage/queries.py
+++ b/irrd/storage/queries.py
@@ -9,6 +9,7 @@ import sqlalchemy.dialects.postgresql as pg
 
 from irrd.conf import get_setting
 from irrd.rpki.status import RPKIStatus
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.rpsl.rpsl_objects import lookup_field_names
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.storage.models import (RPSLDatabaseObject, RPSLDatabaseJournal, RPSLDatabaseStatus,
@@ -354,6 +355,13 @@ class RPSLDatabaseQuery(BaseRPSLObjectDatabaseQuery):
         Filter for RPSL objects with a specific scope filter status.
         """
         fltr = self.columns.scopefilter_status.in_(status)
+        return self._filter(fltr)
+
+    def route_preference_status(self, status: List[RoutePreferenceStatus]):
+        """
+        Filter for RPSL objects with a specific route preference filter status.
+        """
+        fltr = self.columns.route_preference_status.in_(status)
         return self._filter(fltr)
 
     def text_search(self, value: str, extract_asn_ip=True):

--- a/irrd/storage/tests/test_preload.py
+++ b/irrd/storage/tests/test_preload.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 
 from irrd.rpki.status import RPKIStatus
+from irrd.routepref.status import RoutePreferenceStatus
 from irrd.scopefilter.status import ScopeFilterStatus
 from irrd.utils.test_utils import flatten_mock_calls
 from ..database_handler import DatabaseHandler
@@ -170,6 +171,7 @@ class TestPreloadUpdater:
             ['object_classes', (['route', 'route6'],), {}],
             ['rpki_status', ([RPKIStatus.not_found, RPKIStatus.valid],), {}],
             ['scopefilter_status', ([ScopeFilterStatus.in_scope],), {}],
+            ['route_preference_status', ([RoutePreferenceStatus.visible],), {}],
         ]
 
         assert flatten_mock_calls(mock_preload_obj) == [

--- a/irrd/updates/parser.py
+++ b/irrd/updates/parser.py
@@ -310,7 +310,7 @@ class ChangeRequest:
         assert self.rpsl_obj_new
         if self._cached_roa_validity is not None:
             return self._cached_roa_validity
-        if not get_setting('rpki.roa_source') or not self.rpsl_obj_new.rpki_relevant:
+        if not get_setting('rpki.roa_source') or not self.rpsl_obj_new.is_route:
             return True
         # Deletes are permitted for RPKI-invalids, other operations are not
         if self.request_type == UpdateRequestType.DELETE:

--- a/irrd/updates/suspension.py
+++ b/irrd/updates/suspension.py
@@ -145,7 +145,7 @@ def reactivate_for_mntner(database_handler: DatabaseHandler, reactivated_mntner:
             continue
 
         reactivating_obj.scopefilter_status, _ = scopefilter_validator.validate_rpsl_object(reactivating_obj)
-        if get_setting('rpki.roa_source') and reactivating_obj.rpki_relevant and reactivating_obj.asn_first:
+        if get_setting('rpki.roa_source') and reactivating_obj.is_route and reactivating_obj.asn_first:
             reactivating_obj.rpki_status = roa_validator.validate_route(reactivating_obj.prefix, reactivating_obj.asn_first, source)
 
         database_handler.upsert_rpsl_object(reactivating_obj, JournalEntryOrigin.suspension, forced_created_value=result['original_created'])

--- a/irrd/utils/misc.py
+++ b/irrd/utils/misc.py
@@ -1,0 +1,14 @@
+import itertools
+from typing import Iterable
+
+
+def chunked_iterable(iterable: Iterable, size: int) -> Iterable:
+    """
+    Yield chunks from an iterable in chunks of size `size`.
+    """
+    it = iter(iterable)
+    while True:
+        chunk = tuple(itertools.islice(it, size))
+        if not chunk:
+            break
+        yield chunk

--- a/irrd/utils/tests/test_misc.py
+++ b/irrd/utils/tests/test_misc.py
@@ -1,0 +1,6 @@
+from ..misc import chunked_iterable
+
+
+def test_chunked_iterable():
+    inp = range(10)
+    assert list(chunked_iterable(inp, 3)) == [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9,)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ psutil==5.9.4          # Process management
 asgiref==3.6.0         # ASGI utilities
 pydantic==1.10.4        # Input validation
 typing-extensions==4.4.0
+py-radix-sr==1.0.0post1
 
 # Database connections and management
 psycopg2-binary==2.9.5; platform_python_implementation == "CPython"


### PR DESCRIPTION
Adds a new route order preference option, which can suppress route objects if an overlapping higher priority route object exists. Also restructures the docs a bit around this feature.

Docs: https://irrd.readthedocs.io/en/ropref/admins/object-suppression/ and https://irrd.readthedocs.io/en/ropref/admins/route-object-preference/

### Some performance indication

Time taken is proportional to the number of objects that change state.

Numbers from my (Celeron J4115, 32GB, scavenged SATA SSD) testing box:
- Moving from disabled to ALTDB at 50, RADB at 100, others at 900 (typically only done once):
  - 1.099.850 moved to suppressed
  - 7 minutes to scan objects, decide new states, enrich object to be changed
  - 3 hours to generate journal entries for newly suppressed objects
  - 1h28m to update the state of the now suppressed objects
  - 12s to commit the transaction
- Then, changing ALTDB to 150:
  - 9.800 objects moved to visible, 20.000 objects moved to suppressed
  - 2m15s for scan, deciding on new state, enriching, and adding journal entries
  - 33s for updating state
  - 2s to commit the transaction
- Periodic full update when there are no state changes: about 2 minutes for scanning and deciding new state.
- Partial update after e.g. processing an NRTM update: several seconds or shorter.

However, it's questionable whether it makes sense to even enable the journal on these large state changes. NRTMv3 will not scale to catching up with 1 million objects. Therefore, while it may be possible to speed up the journal insert time, it is not particularly useful.

### Todo

- [x] Enable by default on query side
- [x] Support single validator queries
- [x] Fix conflict with #731 (minor)
- [x] Schedule periodically
- [x] Run validator after database changes
- [x] Make sure this behaves correctly when disabled
- [x] Ensure multi-preference overlaps work as intended
- [x] Overlaps with RPKI invalid routes?
- [x] Code TODOs
- [x] Docstrings
- [x] Document log messagee
- [x] Is the trigger specific to route objects or perhaps also picking up inet6num?
- [x] Don't trigger a status check for objects where we just changed the route preference
- [x] Is this in database status call? !J? Status page?
- [x] Is query doc up to date with new !f ?
- [x] Import timer?
- [x] Fix up the pyradix dependency
- [x] Do some real data testing
- [x] Validate new setting
- [x] Documentation
- [x] Review naming
- [x] Refactor/review
- [x] Remove obsolete method
