### PR TITLE
Increase journal insertion speed

### DIFF
--- a/docs/releases/4.3.0.rst
+++ b/docs/releases/4.3.0.rst
@@ -127,3 +127,7 @@ Other changes
   log file, before dropping the privileges. Previously, it would
   drop privileges, then fail to write to the log file, and be unable
   to report this error.
+* Inserting the journal entries is now much faster when inserting
+  multiple entries per source. This happens in NRTM mirroring
+  or when users submit large sets of changes. IRRd will process
+  these changes faster up to an order of magnitude.

--- a/irrd/storage/database_handler.py
+++ b/irrd/storage/database_handler.py
@@ -766,9 +766,12 @@ class DatabaseStatusTracker:
             if self._is_serial_synchronised(source):
                 serial_nrtm = source_serial
             else:
-                serial_nrtm = sa.select([sa.text('COALESCE(MAX(serial_nrtm), 0) + 1')])
-                serial_nrtm = serial_nrtm.where(RPSLDatabaseJournal.__table__.c.source == source)
-                serial_nrtm = serial_nrtm.as_scalar()
+                if source in self._new_serials_per_source and self._new_serials_per_source[source]:
+                    serial_nrtm = max(self._new_serials_per_source[source]) + 1
+                else:
+                    serial_nrtm = sa.select([sa.text('COALESCE(MAX(serial_nrtm), 0) + 1')])
+                    serial_nrtm = serial_nrtm.where(RPSLDatabaseJournal.__table__.c.source == source)
+                    serial_nrtm = serial_nrtm.as_scalar()
             timestamp = datetime.now(timezone.utc)
             stmt = RPSLDatabaseJournal.__table__.insert().values(
                 rpsl_pk=rpsl_pk,


### PR DESCRIPTION
As the journal table is locked per #685 anyways,
we can guarantee that max(_new_serials_per_source)
is the same as running MAX(serial_nrtm) per source
after the first insert.

The MAX(serial_nrtm) query is actually really slow,
so avoiding this has significant benefits, and
reduces the cost of locking the table.

This was extracted from #718 (c8209baa477d0e396b50a21c669b91d877d95c95).