### PR TITLE
[hold for 4.4] Update Sphinx theme to sphinx-immaterial which fixes some bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,14 +375,24 @@ jobs:
         environment:
           PYTHON_INTERPRETER: python3
           SUDO: sudo
+          SPHINX_IMMATERIAL_EXTERNAL_RESOURCE_CACHE_DIR: sphinx_immaterial_cache
 #      - image: cimg/rust:1.65
 
     steps:
       - checkout
       - install_dependencies
 
+      - restore_cache:
+          keys: v1-docs-cache
+
       - run:
           name: build docs
           command: |
             . venv/bin/activate
             sphinx-build -nW -b spelling docs/ docs/build
+
+      - save_cache:
+          paths:
+            - ./sphinx_immaterial_cache
+          key: v1-docs-cache
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,12 @@ import irrd  # noqa: E402
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinxcontrib.spelling']
+extensions = [
+    # 'sphinx.ext.autodoc',
+    # 'sphinx.ext.viewcode',
+    'sphinxcontrib.spelling',
+    "sphinx_immaterial",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -65,7 +70,7 @@ release = irrd.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -84,7 +89,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_material'
+html_theme = 'sphinx_immaterial'
 html_show_sourcelink = False
 
 html_sidebars = {
@@ -96,14 +101,30 @@ html_sidebars = {
 # documentation.
 #
 html_theme_options = {
-    'nav_title': 'IRRd ' + version,
-    'color_primary': 'indigo',
-    'color_accent': 'light-blue',
     'repo_url': 'https://github.com/irrdnet/irrd/',
     'repo_name': 'IRRd',
-    'globaltoc_depth': 2,
-    'master_doc': False,
-    'logo_icon': '&#xe1db',
+    "repo_type": "github",
+    "edit_uri": "blob/main/docs/",
+    "icon": {
+        "repo": "fontawesome/brands/github",
+        "edit": "material/file-edit-outline",
+    },
+    "features": [
+        "navigation.expand",
+        # "navigation.tabs",
+        "toc.integrate",
+        "navigation.sections",
+        # "navigation.instant",
+        # "header.autohide",
+        # "navigation.top",
+        "navigation.tracking",
+        "search.highlight",
+        # "search.share",
+        "toc.follow",
+        # "toc.sticky",
+        # "content.tabs.link",
+        # "announce.dismiss",
+    ],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,9 +46,9 @@ freezegun==1.2.2
 pytest-freezegun==0.4.2
 
 # Documentation generation
-Sphinx==4.3.2  # pyup: <4.4  # importlib-metadata conflict with flake8
-sphinxcontrib-spelling==7.7.0
-sphinx-material==0.0.35
+Sphinx==6.1.3
+sphinxcontrib-spelling==8.0.0
+sphinx-immaterial==0.11.3
 
 # Code style and type checks
 mypy==1.0.0; platform_python_implementation == "CPython"


### PR DESCRIPTION
On hold until 4.3 is out, so we can drop Python 3.7, which works poorly for the library upgrades.