### PR TITLE
Drop Python 3.7 support for 4.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,28 +18,28 @@ workflows:
           name: unit-tests-cpython<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.11"]
+              python_version: ["3.8", "3.11"]
               postgres_version: ["15.0"]
               redis_version: ["5.0"]
       - unit_tests_pypy:
           name: unit-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.9"]
+              python_version: ["3.8", "3.9"]
               postgres_version: ["15.0"]
               redis_version: ["5.0"]
       - integration_tests_cpython:
           name: integration-tests-cpython<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.11"]
+              python_version: ["3.8", "3.11"]
               postgres_version: ["15.0"]
               redis_version: ["5.0"]
       - integration_tests_pypy:
           name: integration-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.9"]
+              python_version: ["3.8", "3.9"]
               postgres_version: ["15.0"]
               redis_version: ["5.0"]
       - lint:
@@ -57,28 +57,28 @@ workflows:
           name: unit-tests-cpython<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+              python_version: ["3.8", "3.9", "3.10", "3.11"]
               postgres_version: ["9.6", "11.16", "13.7", "15.0"]
               redis_version: ["5.0", "6.2", "7.0"]
       - unit_tests_pypy:
           name: unit-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.8", "3.9"]
               postgres_version: ["9.6", "11.16", "13.7", "15.0"]
               redis_version: ["5.0", "6.2", "7.0"]
       - integration_tests_cpython:
           name: integration-tests-cpython<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+              python_version: ["3.8", "3.9", "3.10", "3.11"]
               postgres_version: ["9.6", "11.16", "13.7", "15.0"]
               redis_version: ["5.0", "6.2", "7.0"]
       - integration_tests_pypy:
           name: integration-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.8", "3.9"]
               postgres_version: ["9.6", "11.16", "13.7", "15.0"]
               redis_version: ["5.0", "6.2", "7.0"]
       - lint:

--- a/docs/admins/deployment.rst
+++ b/docs/admins/deployment.rst
@@ -20,7 +20,7 @@ Requirements
 IRRd requires:
 
 * Linux, OpenBSD or MacOS. Other platforms are untested, but may work.
-* PyPy or CPython 3.7 through 3.11 with `pip` and `virtualenv` installed.
+* PyPy or CPython 3.8 through 3.11 with `pip` and `virtualenv` installed.
   PyPy is slightly recommended over CPython (the "default" Python interpreter),
   due to improved performance, in the order of 10% for some queries,
   and even higher for some GraphQL queries. However, CPython remains fully

--- a/docs/releases/4.4.0.rst
+++ b/docs/releases/4.4.0.rst
@@ -1,0 +1,32 @@
+==================================
+DRAFT Release notes for IRRd 4.4.0
+==================================
+
+Minimum Python version
+----------------------
+The minimum Python version for IRRd is now 3.8. Python 3.7 is `end of life`_
+as of 27 June 2023 and therefore no longer supported.
+
+.. _end of life: https://endoflife.date/python
+
+
+Upgrading to IRRd 4.4.0 from 4.3.x
+----------------------------------
+TODO
+
+
+Downgrading from 4.4 to 4.3.x
+-----------------------------
+If you are running IRRd 4.4, and would like to downgrade back to 4.3.x,
+the database schema needs to be modified. You can either restore an older
+copy of your database, start with a fresh database, or use the database
+migrations.
+
+If you want to use the database migrations, run this command **before**
+downgrading your local package installation to 4.3.x::
+
+    irrd_database_downgrade --version TODO-TODO
+
+If you would like to re-upgrade to 4.4 later on, you will need to run
+the database migrations again, as listed in the upgrade steps.
+

--- a/irrd/scripts/tests/test_irr_rpsl_submit.py
+++ b/irrd/scripts/tests/test_irr_rpsl_submit.py
@@ -163,7 +163,7 @@ class APIResult:
 
 class APIBadResponse:
     def read(self):
-        return "This is not JSON".encode("utf-8")
+        return b"This is not JSON"
 
 
 class Runner:

--- a/irrd/server/http/event_stream.py
+++ b/irrd/server/http/event_stream.py
@@ -14,7 +14,7 @@ from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse, PlainTextResponse
 from starlette.status import WS_1003_UNSUPPORTED_DATA, WS_1008_POLICY_VIOLATION
 from starlette.websockets import WebSocket
-from typing_extensions import Literal
+from typing import Literal
 
 from irrd.conf import get_setting
 from irrd.rpki.status import RPKIStatus

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,7 @@ coredis==4.10.2         # async redis
 requests==2.28.2       # HTTP request handling
 pytz==2022.7.1
 ariadne==0.17.1
-uvicorn==0.20.0        # ASGI server
-uvicorn[standard]==0.20.0; python_version > '3.7'  # ASGI server extras
-websockets==10.4; python_version < '3.8'  # serving websockets
+uvicorn[standard]==0.20.0  # ASGI server
 starlette==0.20.4      # pyup: <0.21  # ariadne conflict
 psutil==5.9.4          # Process management
 asgiref==3.6.0         # ASGI utilities
@@ -46,7 +44,6 @@ python-graphql-client==0.4.3
 pytest-asyncio==0.20.3
 freezegun==1.2.2
 pytest-freezegun==0.4.2
-asyncmock==0.4.2; python_version < '3.8'
 
 # Documentation generation
 Sphinx==4.3.2  # pyup: <4.4  # importlib-metadata conflict with flake8
@@ -55,7 +52,7 @@ sphinx-material==0.0.35
 
 # Code style and type checks
 mypy==1.0.0; platform_python_implementation == "CPython"
-flake8==6.0.0; python_version >= '3.8'
+flake8==6.0.0
 pep8-naming==0.13.3
 
 # Creating python packages

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(
         exclude=['*.tests', '*.tests.*', 'tests.*', 'tests', 'irrd.integration_tests']
     ),
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     package_data={'': ['*.txt', '*.yaml', '*.mako']},
     install_requires=[
         # This list must be kept in sync with requirements.txt version-wise,
@@ -40,7 +40,7 @@ setuptools.setup(
         'requests==2.28.2',
         'pytz==2022.7.1',
         'ariadne==0.17.1',
-        'uvicorn==0.20.0',
+        'uvicorn[standard]==0.20.0',
         'starlette==0.20.4',
         'psutil==5.9.4',
         'asgiref==3.6.0',
@@ -53,12 +53,6 @@ setuptools.setup(
         'wheel==0.38.4',
     ],
     extras_require={
-        ':python_version > "3.7"': [
-            'uvicorn[standard]==0.20.0',
-        ],
-        ':python_version < "3.8"': [
-            'websockets==10.4',
-        ],
         ':platform_python_implementation == "CPython"': [
             'psycopg2-binary==2.9.5',
         ],
@@ -84,7 +78,6 @@ setuptools.setup(
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Python 3.7 goes EOL in 27 June 2023, this release will be shortly before 
or after this date, so it will be 3.8+
