### PR TITLE
Add FTP mirroring timeout

### DIFF
--- a/irrd/mirroring/mirror_runners_import.py
+++ b/irrd/mirroring/mirror_runners_import.py
@@ -167,7 +167,7 @@ class FileImportRunnerBase:
         """
         if url_parsed.scheme == "ftp":
             try:
-                r = request.urlopen(url)
+                r = request.urlopen(url, timeout=10)
                 shutil.copyfileobj(r, destination)
             except URLError as error:
                 raise OSError(f"Failed to download {url}: {str(error)}")

--- a/irrd/mirroring/mirror_runners_import.py
+++ b/irrd/mirroring/mirror_runners_import.py
@@ -26,6 +26,7 @@ from irrd.utils.whois_client import whois_query
 from .parsers import MirrorFileImportParser, NRTMStreamParser
 
 logger = logging.getLogger(__name__)
+DOWNLOAD_TIMEOUT = 10
 
 
 class RPSLMirrorImportUpdateRunner:
@@ -167,12 +168,12 @@ class FileImportRunnerBase:
         """
         if url_parsed.scheme == "ftp":
             try:
-                r = request.urlopen(url, timeout=10)
+                r = request.urlopen(url, timeout=DOWNLOAD_TIMEOUT)
                 shutil.copyfileobj(r, destination)
             except URLError as error:
                 raise OSError(f"Failed to download {url}: {str(error)}")
         elif url_parsed.scheme in ["http", "https"]:
-            r = requests.get(url, stream=True, timeout=10)
+            r = requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT)
             if r.status_code == 200:
                 for chunk in r.iter_content(10240):
                     destination.write(chunk)

--- a/irrd/mirroring/tests/test_mirror_runners_import.py
+++ b/irrd/mirroring/tests/test_mirror_runners_import.py
@@ -189,7 +189,7 @@ class TestRPSLMirrorFullImportRunner:
             "ftp://host/source2": b"source2",
             "ftp://host/serial": b"424242",
         }
-        request.urlopen = lambda url: MockUrlopenResponse(responses[url])
+        request.urlopen = lambda url, timeout: MockUrlopenResponse(responses[url])
         RPSLMirrorFullImportRunner("TEST").run(mock_dh, serial_newest_mirror=424241)
 
         assert MockMirrorFileImportParser.rpsl_data_calls == ["source1", "source2"]
@@ -225,7 +225,7 @@ class TestRPSLMirrorFullImportRunner:
             "irrd.mirroring.mirror_runners_import.BulkRouteROAValidator", mock_bulk_validator_init
         )
 
-        request.urlopen = lambda url: MockUrlopenResponse(b"", fail=True)
+        request.urlopen = lambda url, timeout: MockUrlopenResponse(b"", fail=True)
         with pytest.raises(IOError):
             RPSLMirrorFullImportRunner("TEST").run(mock_dh, serial_newest_mirror=424241)
 
@@ -296,7 +296,7 @@ class TestRPSLMirrorFullImportRunner:
             "ftp://host/source1.gz": b64decode("H4sIAE4CfFsAAyvOLy1KTjUEAE5Fj0oHAAAA"),
             "ftp://host/source2": b"source2",
         }
-        request.urlopen = lambda url: MockUrlopenResponse(responses[url])
+        request.urlopen = lambda url, timeout: MockUrlopenResponse(responses[url])
         RPSLMirrorFullImportRunner("TEST").run(mock_dh, serial_newest_mirror=42)
 
         assert MockMirrorFileImportParser.rpsl_data_calls == ["source1", "source2"]
@@ -331,7 +331,7 @@ class TestRPSLMirrorFullImportRunner:
             "ftp://host/source2": b"source2",
             "ftp://host/serial": b"424242",
         }
-        request.urlopen = lambda url: MockUrlopenResponse(responses[url])
+        request.urlopen = lambda url, timeout: MockUrlopenResponse(responses[url])
         RPSLMirrorFullImportRunner("TEST").run(mock_dh, serial_newest_mirror=424243)
 
         assert not MockMirrorFileImportParser.rpsl_data_calls
@@ -365,7 +365,7 @@ class TestRPSLMirrorFullImportRunner:
             "ftp://host/source2": b"source2",
             "ftp://host/serial": b"424242",
         }
-        request.urlopen = lambda url: MockUrlopenResponse(responses[url])
+        request.urlopen = lambda url, timeout: MockUrlopenResponse(responses[url])
         RPSLMirrorFullImportRunner("TEST").run(mock_dh, serial_newest_mirror=424243, force_reload=True)
 
         assert MockMirrorFileImportParser.rpsl_data_calls == ["source1", "source2"]


### PR DESCRIPTION
Hi!

I've got an issue, when mirroring stuck for hours when polling data from FTP source.
As I see in code, timeout is specified only for HTTP\HTTPS sources but not for FTP. 
Would you mind looking my little fix?

Sincerely, Alex.