### PR TITLE
Ensure tmp files are deleted on failed import

### DIFF
--- a/irrd/mirroring/mirror_runners_import.py
+++ b/irrd/mirroring/mirror_runners_import.py
@@ -262,9 +262,13 @@ class RPSLMirrorFullImportRunner(FileImportRunnerBase):
                 database_handler=database_handler,
                 roa_validator=roa_validator,
             )
-            p.run_import()
-            if to_delete:
-                os.unlink(import_filename)
+
+            try:
+                p.run_import()
+            finally:
+                if to_delete:
+                    os.unlink(import_filename)
+
         if import_serial:
             database_handler.record_serial_newest_mirror(self.source, import_serial)
 

--- a/irrd/mirroring/mirror_runners_import.py
+++ b/irrd/mirroring/mirror_runners_import.py
@@ -262,7 +262,6 @@ class RPSLMirrorFullImportRunner(FileImportRunnerBase):
                 database_handler=database_handler,
                 roa_validator=roa_validator,
             )
-
             try:
                 p.run_import()
             finally:


### PR DESCRIPTION
I know that this error is a red herring - https://irrd.readthedocs.io/en/stable/admins/faq/#postgresql-error-about-multirow-inserts - but the IRR import process causes issues with Postgres and large inserts, this commit ensures that the files are unlinked from /tmp regardless if it errors out or not in the import earlier in the thread.

This was running on a 32G ram instance mirroring from all sources and filled our /tmp up nice and quick.