### PR TITLE
Fix #774 - Fix NRTM generator performance on PyPy

### DIFF
--- a/irrd/mirroring/nrtm_generator.py
+++ b/irrd/mirroring/nrtm_generator.py
@@ -79,18 +79,18 @@ class NRTMGenerator:
             .sources([source])
             .serial_nrtm_range(serial_start_requested, serial_end_requested)
         )
-        operations = list(database_handler.execute_query(q))
 
-        output = f"%START Version: {version} {source} {serial_start_requested}-{serial_end_display}\n"
+        output = [f"%START Version: {version} {source} {serial_start_requested}-{serial_end_display}\n"]
 
-        for operation in operations:
-            output += "\n" + operation["operation"].value
+        for operation in database_handler.execute_query(q):
+            operation_str = operation["operation"].value
             if version == "3":
-                output += " " + str(operation["serial_nrtm"])
+                operation_str += " " + str(operation["serial_nrtm"])
             text = operation["object_text"]
             if remove_auth_hashes:
                 text = remove_auth_hashes_func(text)
-            output += "\n\n" + text
+            operation_str += "\n\n" + text
+            output.append(operation_str)
 
-        output += f"\n%END {source}"
-        return output
+        output += [f"%END {source}"]
+        return "\n".join(output)

--- a/irrd/mirroring/nrtm_generator.py
+++ b/irrd/mirroring/nrtm_generator.py
@@ -92,5 +92,5 @@ class NRTMGenerator:
             operation_str += "\n\n" + text
             output.append(operation_str)
 
-        output += [f"%END {source}"]
+        output.append(f"%END {source}")
         return "\n".join(output)


### PR DESCRIPTION
Apparently, PyPy deals quite poorly when extending the same string many times, as the old code did. Requesting 500.000 serials in one NRTM query, response 181MB, was now ~30 seconds on both PyPy and CPython in a testing setup.