### PR TITLE
add asdot syntax support

### DIFF
--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -941,5 +941,10 @@ Compatibility
   performance impact on very large responses.
   |br| **Default**: ``false``, IPv6 members included.
   |br| **Change takes effect**: after SIGHUP, for all subsequent queries.
+* ``compatibility.asdot_queries``: if set to ``true``, origin queries will
+  also accept queries in the (long deprecated) asdot format for AS numbers.
+  In other places, like object attributes, asdot remains invalid.
+  |br| **Default**: ``false``, asdot not valid.
+  |br| **Change takes effect**: after SIGHUP, for all subsequent queries.
 
 .. _RFC8416: https://tools.ietf.org/html/rfc8416

--- a/docs/releases/4.4.0.rst
+++ b/docs/releases/4.4.0.rst
@@ -85,6 +85,11 @@ alias relates only to the query. The database status under the ``!J`` whois
 and the ``databaseStatus`` GraphQL queries is extended with alias
 information.
 
+Other changes
+-------------
+* A ``compatibility.asdot_queries`` setting was added, which allows
+  the use of the (long deprecated) asdot format in origin queries.
+
 Upgrading to IRRd 4.4.0 from 4.3.x
 ----------------------------------
 TODO

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+asdot
 ASes
 aut
 auth

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -77,6 +77,7 @@ KNOWN_CONFIG_KEYS = DottedDict(
         "compatibility": {
             "inetnum_search_disabled": {},
             "ipv4_only_route_set_members": {},
+            "asdot_queries": {},
         },
     }
 )

--- a/irrd/server/whois/query_parser.py
+++ b/irrd/server/whois/query_parser.py
@@ -222,7 +222,7 @@ class WhoisQueryParser:
         of all originating prefixes, not including duplicates.
         """
         try:
-            origin_formatted, _ = parse_as_number(origin)
+            origin_formatted, _ = parse_as_number(origin, asdot_permitted=True)
         except ValidationError as ve:
             raise InvalidQueryException(str(ve))
 

--- a/irrd/storage/queries.py
+++ b/irrd/storage/queries.py
@@ -397,7 +397,7 @@ class RPSLDatabaseQuery(BaseRPSLObjectDatabaseQuery):
         self._check_query_frozen()
         if extract_asn_ip:
             try:
-                _, asn = parse_as_number(value)
+                _, asn = parse_as_number(value, asdot_permitted=True)
                 return self.object_classes(["as-block", "as-set", "aut-num"]).asn_less_specific(asn)
             except ValidationError:
                 pass

--- a/irrd/utils/tests/test_validators.py
+++ b/irrd/utils/tests/test_validators.py
@@ -17,6 +17,10 @@ def test_validate_as_number():
     assert "must start with" in str(ve.value)
 
     with raises(ValidationError) as ve:
+        parse_as_number("AS1.10")
+    assert "number part is not numeric" in str(ve.value)
+
+    with raises(ValidationError) as ve:
         parse_as_number("ASFOO")
     assert "number part is not numeric" in str(ve.value)
 
@@ -30,28 +34,32 @@ def test_validate_asdot_as_number(config_override):
 
     test_validate_as_number()
 
-    assert parse_as_number("AS1.10") == ("AS65546", 65546)
-    assert parse_as_number("1.10", permit_plain=True) == ("AS65546", 65546)
+    assert parse_as_number("AS1.10", asdot_permitted=True) == ("AS65546", 65546)
+    assert parse_as_number("1.10", permit_plain=True, asdot_permitted=True) == ("AS65546", 65546)
 
     with raises(ValidationError) as ve:
-        parse_as_number("AS1.2.3")
+        parse_as_number("AS1.2.3", asdot_permitted=True)
     assert "number is not valid asdot format" in str(ve.value)
 
     with raises(ValidationError) as ve:
-        parse_as_number("AS.10")
+        parse_as_number("AS.10", asdot_permitted=True)
     assert "high order value missing" in str(ve.value)
 
     with raises(ValidationError) as ve:
-        parse_as_number("AS65546.10")
+        parse_as_number("AS65546.10", asdot_permitted=True)
     assert "high order value out of range" in str(ve.value)
 
     with raises(ValidationError) as ve:
-        parse_as_number("AS1.")
+        parse_as_number("AS1.", asdot_permitted=True)
     assert "low order value missing" in str(ve.value)
 
     with raises(ValidationError) as ve:
-        parse_as_number("AS1.65546")
+        parse_as_number("AS1.65546", asdot_permitted=True)
     assert "low order value out of range" in str(ve.value)
+
+    with raises(ValidationError) as ve:
+        parse_as_number("AS1.10")
+    assert "number part is not numeric" in str(ve.value)
 
 
 def test_validate_rpsl_change_submission():

--- a/irrd/utils/tests/test_validators.py
+++ b/irrd/utils/tests/test_validators.py
@@ -11,8 +11,6 @@ def test_validate_as_number():
     assert parse_as_number("as4294967295") == ("AS4294967295", 4294967295)
     assert parse_as_number("012345", permit_plain=True) == ("AS12345", 12345)
     assert parse_as_number(12345, permit_plain=True) == ("AS12345", 12345)
-    assert parse_as_number("AS1.10") == ("AS65546", 65546)
-    assert parse_as_number("1.10", permit_plain=True) == ("AS65546", 65546)
 
     with raises(ValidationError) as ve:
         parse_as_number("12345")
@@ -25,6 +23,15 @@ def test_validate_as_number():
     with raises(ValidationError) as ve:
         parse_as_number("AS4294967296")
     assert "valid range is" in str(ve.value)
+
+
+def test_validate_asdot_as_number(config_override):
+    config_override({"compatibility": {"asdot_queries": True}})
+
+    test_validate_as_number()
+
+    assert parse_as_number("AS1.10") == ("AS65546", 65546)
+    assert parse_as_number("1.10", permit_plain=True) == ("AS65546", 65546)
 
     with raises(ValidationError) as ve:
         parse_as_number("AS1.2.3")
@@ -45,6 +52,7 @@ def test_validate_as_number():
     with raises(ValidationError) as ve:
         parse_as_number("AS1.65546")
     assert "low order value out of range" in str(ve.value)
+
 
 def test_validate_rpsl_change_submission():
     result = RPSLChangeSubmission.parse_obj(

--- a/irrd/utils/tests/test_validators.py
+++ b/irrd/utils/tests/test_validators.py
@@ -11,6 +11,8 @@ def test_validate_as_number():
     assert parse_as_number("as4294967295") == ("AS4294967295", 4294967295)
     assert parse_as_number("012345", permit_plain=True) == ("AS12345", 12345)
     assert parse_as_number(12345, permit_plain=True) == ("AS12345", 12345)
+    assert parse_as_number("AS1.10") == ("AS65546", 65546)
+    assert parse_as_number("1.10", permit_plain=True) == ("AS65546", 65546)
 
     with raises(ValidationError) as ve:
         parse_as_number("12345")
@@ -24,6 +26,25 @@ def test_validate_as_number():
         parse_as_number("AS4294967296")
     assert "valid range is" in str(ve.value)
 
+    with raises(ValidationError) as ve:
+        parse_as_number("AS1.2.3")
+    assert "number is not valid asdot format" in str(ve.value)
+
+    with raises(ValidationError) as ve:
+        parse_as_number("AS.10")
+    assert "high order value missing" in str(ve.value)
+
+    with raises(ValidationError) as ve:
+        parse_as_number("AS65546.10")
+    assert "high order value out of range" in str(ve.value)
+
+    with raises(ValidationError) as ve:
+        parse_as_number("AS1.")
+    assert "low order value missing" in str(ve.value)
+
+    with raises(ValidationError) as ve:
+        parse_as_number("AS1.65546")
+    assert "low order value out of range" in str(ve.value)
 
 def test_validate_rpsl_change_submission():
     result = RPSLChangeSubmission.parse_obj(

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -7,7 +7,10 @@ from irrd.updates.parser_state import SuspensionRequestType
 
 
 def parse_as_number(value: Union[str, int], permit_plain=False, asdot_permitted=False) -> Tuple[str, int]:
-    """Validate and clean an AS number. Returns it in ASxxxx and numeric format."""
+    """
+    Validate and clean an AS number. Returns it in ASxxxx and numeric format.
+    asdot is permitted (#790) if asdot_permitted is passed and compatibility.asdot_queries is set
+    """
     if isinstance(value, str):
         value = value.upper()
         if not permit_plain and not value.startswith("AS"):

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -15,11 +15,11 @@ def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, in
 
         start_index = 2 if value.startswith("AS") else 0
 
-        if get_setting("compatibility.asdot_queries") is True and '.' in value[start_index:]:
-            if value[start_index:].count('.') > 1:
+        if get_setting("compatibility.asdot_queries") is True and "." in value[start_index:]:
+            if value[start_index:].count(".") > 1:
                 raise ValidationError(f"Invalid AS number {value}: number is not valid asdot format")
 
-            high, low = [int(i) if i.isnumeric() else None for i in value[start_index:].split('.')]
+            high, low = [int(i) if i.isnumeric() else None for i in value[start_index:].split(".")]
 
             if high is None:
                 raise ValidationError(f"Invalid AS number {value}: high order value missing")

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -2,8 +2,8 @@ from typing import List, Optional, Tuple, Union
 
 import pydantic
 
-from irrd.updates.parser_state import SuspensionRequestType
 from irrd.conf import get_setting
+from irrd.updates.parser_state import SuspensionRequestType
 
 
 def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, int]:

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -19,12 +19,12 @@ def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, in
             if value[start_index:].count('.') > 1:
                 raise ValidationError(f"Invalid AS number {value}: number is not valid asdot format")
 
-            high, low = [int(i) if i.isnumeric() else i for i in value[start_index:].split('.')]
+            high, low = [int(i) if i.isnumeric() else None for i in value[start_index:].split('.')]
 
-            if not high:
+            if high is None:
                 raise ValidationError(f"Invalid AS number {value}: high order value missing")
 
-            if not low:
+            if low is None:
                 raise ValidationError(f"Invalid AS number {value}: low order value missing")
 
             if high > 65535:

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -27,11 +27,11 @@ def parse_as_number(value: Union[str, int], permit_plain=False, asdot_permitted=
             try:
                 high = int(high_str)
             except ValueError:
-                raise ValidationError(f"Invalid AS number {value}: high order value missing")
+                raise ValidationError(f"Invalid AS number {value}: high order value missing or invalid")
             try:
                 low = int(low_str)
             except ValueError:
-                raise ValidationError(f"Invalid AS number {value}: low order value missing")
+                raise ValidationError(f"Invalid AS number {value}: low order value missing or invalid")
 
             if high > 65535:
                 raise ValidationError(f"Invalid AS number {value}: high order value out of range")

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple, Union
 import pydantic
 
 from irrd.updates.parser_state import SuspensionRequestType
+from irrd.conf import get_setting
 
 
 def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, int]:
@@ -14,7 +15,7 @@ def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, in
 
         start_index = 2 if value.startswith("AS") else 0
 
-        if '.' in value[start_index:]:
+        if get_setting("compatibility.asdot_queries") is True and '.' in value[start_index:]:
             if value[start_index:].count('.') > 1:
                 raise ValidationError(f"Invalid AS number {value}: number is not valid asdot format")
 
@@ -23,7 +24,7 @@ def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, in
             if not high:
                 raise ValidationError(f"Invalid AS number {value}: high order value missing")
 
-            if  not low:
+            if not low:
                 raise ValidationError(f"Invalid AS number {value}: low order value missing")
 
             if high > 65535:
@@ -34,11 +35,12 @@ def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, in
 
             value_int = high * 65536 + low
 
-        elif not value[start_index:].isnumeric():
-            raise ValidationError(f"Invalid AS number {value}: number part is not numeric")
-
         else:
-            value_int = int(value[start_index:])
+            if not value[start_index:].isnumeric():
+                raise ValidationError(f"Invalid AS number {value}: number part is not numeric")
+            else:
+                value_int = int(value[start_index:])
+
     else:
         value_int = value
 

--- a/irrd/utils/validators.py
+++ b/irrd/utils/validators.py
@@ -14,10 +14,31 @@ def parse_as_number(value: Union[str, int], permit_plain=False) -> Tuple[str, in
 
         start_index = 2 if value.startswith("AS") else 0
 
-        if not value[start_index:].isnumeric():
+        if '.' in value[start_index:]:
+            if value[start_index:].count('.') > 1:
+                raise ValidationError(f"Invalid AS number {value}: number is not valid asdot format")
+
+            high, low = [int(i) if i.isnumeric() else i for i in value[start_index:].split('.')]
+
+            if not high:
+                raise ValidationError(f"Invalid AS number {value}: high order value missing")
+
+            if  not low:
+                raise ValidationError(f"Invalid AS number {value}: low order value missing")
+
+            if high > 65535:
+                raise ValidationError(f"Invalid AS number {value}: high order value out of range")
+
+            if low > 65535:
+                raise ValidationError(f"Invalid AS number {value}: low order value out of range")
+
+            value_int = high * 65536 + low
+
+        elif not value[start_index:].isnumeric():
             raise ValidationError(f"Invalid AS number {value}: number part is not numeric")
 
-        value_int = int(value[start_index:])
+        else:
+            value_int = int(value[start_index:])
     else:
         value_int = value
 


### PR DESCRIPTION
# Problem

At RADB we are seeing a significant amount of queries in [RFC5396](https://datatracker.ietf.org/doc/html/rfc5396) asdot+ syntax. This format is not currently supported in v4, instead returning `F Invalid AS number AS1.1234: number part is not numeric`. 

# Solution

Update `parse_as_number()` to support parsing this format and converting to asplain format. 

# Testing

Test the configuration change with `pytest` with the `poetry` shell. Tests passing in development.

```bash
$ poetry shell
$ pytest irrd/conf/test_conf.py
```

# Notes

* reference to where [irrd v3](https://github.com/irrdnet/irrd-legacy/blob/main/src/programs/IRRd/hash_spec.c#L468) handles this case for `!g` and `!6`.
* These queries are likely coming from tools such as [bgpq3](https://github.com/snar/bgpq3) and [bgp4](https://github.com/bgp/bgpq4) but I haven't been able to duplicate.