### PR TITLE
Add new sync method to support #617 using txid poller to fix #656

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
+        command: postgres -c track_commit_timestamp=true
 
       - image: cimg/redis:<< parameters.redis_version >>
 #      - image: cimg/rust:1.65
@@ -233,6 +234,7 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
+        command: postgres -c track_commit_timestamp=true
 
       - image: cimg/redis:<< parameters.redis_version >>
 #      - image: cimg/rust:1.65
@@ -271,6 +273,7 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
+        command: postgres -c track_commit_timestamp=true
 
       - image: cimg/redis:<< parameters.redis_version >>
 #      - image: cimg/rust:1.65
@@ -310,6 +313,7 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
+        command: postgres -c track_commit_timestamp=true
 
       - image: cimg/redis:<< parameters.redis_version >>
 #      - image: cimg/rust:1.65

--- a/docs/admins/availability-and-migration.rst
+++ b/docs/admins/availability-and-migration.rst
@@ -74,9 +74,9 @@ There are several important requirements for this setup:
 * The standby must run a PostgreSQL streaming replication from the
   active instance. Logical replication is not supported.
 * The PostgreSQL configuration must have ``track_commit_timestamp``
-  enabled.
-* On the standby, you run the IRRD instance with the ``database_readonly``
-  and ``standby`` parameters set.
+  and ``hot_standby_feedback`` enabled.
+* On the standby, you run the IRRD instance with the ``readonly_standby``
+  parameters set.
 * The standby instance must use its own Redis instance. Do not use
   Redis replication.
 * ``rpki.roa_source`` must be consistent between active and standby
@@ -87,11 +87,15 @@ There are several important requirements for this setup:
   and standby. Note that you can not set
   ``sources.{name}.authoritative``, ``sources.{name}.nrtm_host``, or
   ``sources.{name}.import_source`` on a standby instance, as these
-  conflict with ``database_readonly``.
+  conflict with ``readonly_standby``.
 * It is recommended that all PostgreSQL instances only host the IRRd
   database. Streaming replication will always include all databases,
   and commits received on the standby in any database will trigger
   a local preloaded data refresh.
+* Although the details of PostgreSQL are out of scope for
+  this documentation, the use of replication slots is recommended.
+  Make sure to drop a replication slot if you decommission a
+  standby server, to prevent infinite PostgreSQL WAL growth.
 
 As replication replicates the entire database, any IRR registries
 mirrored on the active instance, are also mirrored on the standby,
@@ -122,7 +126,7 @@ The general plan for promoting an IRRDv4 instance is:
 * Hold all update emails.
 * Ensure PostgreSQL replication is up to date.
 * Promote the PostgreSQL replica to become a main server.
-* Disable the ``database_readonly`` and ``standby`` settings in IRRd.
+* Disable the ``readonly_standby`` setting in IRRd.
 * Make sure your IRRD configuration on the standby is up to date
   compared to the old active (ideally, manage this continuously).
   Make sure the ``authoritative`` setting is enabled on your authoritative

--- a/docs/admins/availability-and-migration.rst
+++ b/docs/admins/availability-and-migration.rst
@@ -79,6 +79,15 @@ There are several important requirements for this setup:
   and ``standby`` parameters set.
 * The standby instance must use its own Redis instance. Do not use
   Redis replication.
+* ``rpki.roa_source`` must be consistent between active and standby
+  configurations.
+* You are recommended to keep other settings, like ``scopefilter``,
+  ``sources.{name}.route_object_preference``,
+  ``sources.{name}.object_class_filter`` consistent between active
+  and standby. Note that you can not set
+  ``sources.{name}.authoritative``, ``sources.{name}.nrtm_host``, or
+  ``sources.{name}.import_source`` on a standby instance, as these
+  conflict with ``database_readonly``.
 * It is recommended that all PostgreSQL instances only host the IRRd
   database. Streaming replication will always include all databases,
   and commits received on the standby in any database will trigger
@@ -102,6 +111,10 @@ inconsistencies after promoting a standby, you are encouraged to keep
 the object suppression settings identical on all instances, even
 if some are (currently) not used.
 
+For RPKI, ``rpki.roa_source`` must be consistent between active and
+standby, because that setting determines whether the query parser
+considers ``RPKI`` a valid source.
+
 Promoting a standby instance to active
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The general plan for promoting an IRRDv4 instance is:
@@ -122,6 +135,9 @@ The general plan for promoting an IRRDv4 instance is:
   for authentication.
 * Redirect update emails to the new instance.
 * Ensure published exports are now taken from the new instance.
+* Check the mirroring status to ensure the new active instance
+  has access to all exports and NRTM streams (some other operators
+  restrict NRTM access to certain IPs).
 
 .. warning::
     If users use IRRD internal authentication, by logging in through

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -205,6 +205,13 @@ General settings
   ``import_source`` or ``nrtm_host`` set.
   |br| **Default**: ``false``.
   |br| **Change takes effect**: after full IRRd restart.
+* ``standby``: a boolean for whether this instance is
+  in standby mode. See
+  :doc:`availability with PostgreSQL replication </admins/availability-and-migration>`
+  for further details. Requires ``database_readonly`` to be set.
+  **Do not enable this setting without reading the further documentation on standby setups.**
+  |br| **Default**: ``false``.
+  |br| **Change takes effect**: after full IRRd restart.
 * ``redis_url``: a URL to a Redis instance, e.g.
   ``unix:///var/run/redis.sock`` to connect through a unix socket, or
   ``redis://localhost`` to connect through TCP.
@@ -664,6 +671,7 @@ Sources
   Sharing password hashes externally is a security risk, the unfiltered data
   is intended only to support
   :doc:`availability and data migration </admins/availability-and-migration>`.
+  **This setting is deprecated and will be removed in IRRD 4.5.**
   |br| **Default**: not defined, no exports made.
   |br| **Change takes effect**: after SIGHUP, at the next ``export_timer``.
 * ``sources.{name}.export_timer``: the time between two full exports of all
@@ -686,6 +694,8 @@ Sources
   Unfiltered means full password hashes are included.
   Sharing password hashes externally is a security risk, the unfiltered data
   is intended only to support
+  :doc:`availability and data migration </admins/availability-and-migration>`.
+  **This setting is deprecated and will be removed in IRRD 4.5.**
   |br| **Default**: not defined, all access denied. Clients in
   ``nrtm_access_list``, if defined, have filtered access.
   |br| **Change takes effect**: after SIGHUP, upon next request.

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -196,19 +196,11 @@ General settings
   for improved performance
   |br| **Default**: not defined, but required.
   |br| **Change takes effect**: after full IRRd restart.
-* ``database_readonly``: a boolean for whether this instance is
-  database read only, i.e. IRRd will never write any changes to the SQL database
-  in any circumstance. This can be used for
-  :doc:`availability with PostgreSQL replication </admins/availability-and-migration>`.
-  This setting means that this IRRd instance will never run the RPKI or scope
-  filter validators, and can not be used if any source has ``authoritative``,
-  ``import_source`` or ``nrtm_host`` set.
-  |br| **Default**: ``false``.
-  |br| **Change takes effect**: after full IRRd restart.
-* ``standby``: a boolean for whether this instance is
-  in standby mode. See
+* ``readonly_standby``: a boolean for whether this instance is
+  in read-only standby mode. See
   :doc:`availability with PostgreSQL replication </admins/availability-and-migration>`
-  for further details. Requires ``database_readonly`` to be set.
+  for further details. Can not be used if any source has ``authoritative``,
+  ``import_source`` or ``nrtm_host`` set.
   **Do not enable this setting without reading the further documentation on standby setups.**
   |br| **Default**: ``false``.
   |br| **Change takes effect**: after full IRRd restart.

--- a/docs/admins/deployment.rst
+++ b/docs/admins/deployment.rst
@@ -99,8 +99,6 @@ size of the RPSL text imported.
 
     The PostgreSQL database is the only source of IRRd's data.
     This means you need to run regular backups of the database.
-    It is also possible to restore data from recent exports,
-    but changes made since the most recent export will be lost.
 
 .. _deployment-redis-configuration:
 

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -268,9 +268,6 @@ class Configuration:
             config.get("server.http.status_access_list"),
         }
 
-        if config.get("standby") and not config.get("database_readonly"):
-            errors.append("Setting standby can only be set combined with database_readonly.")
-
         if not self._check_is_str(config, "email.from") or "@" not in config.get("email.from", ""):
             errors.append("Setting email.from is required and must be an email address.")
         if not self._check_is_str(config, "email.smtp"):
@@ -399,12 +396,12 @@ class Configuration:
                     "nrtm_host or import_source are set."
                 )
 
-            if config.get("database_readonly") and (
+            if config.get("readonly_standby") and (
                 details.get("authoritative") or details.get("nrtm_host") or details.get("import_source")
             ):
                 errors.append(
                     f"Source {name} can not have authoritative, import_source or nrtm_host set "
-                    "when database_readonly is enabled."
+                    "when readonly_standby is enabled."
                 )
 
             number_fields = [

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -268,6 +268,9 @@ class Configuration:
             config.get("server.http.status_access_list"),
         }
 
+        if config.get("standby") and not config.get("database_readonly"):
+            errors.append("Setting standby can only be set combined with database_readonly.")
+
         if not self._check_is_str(config, "email.from") or "@" not in config.get("email.from", ""):
             errors.append("Setting email.from is required and must be an email address.")
         if not self._check_is_str(config, "email.smtp"):

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -8,8 +8,7 @@ from irrd.vendor.dotted.collection import DottedDict
 KNOWN_CONFIG_KEYS = DottedDict(
     {
         "database_url": {},
-        "database_readonly": {},
-        "standby": {},
+        "readonly_standby": {},
         "redis_url": {},
         "piddir": {},
         "user": {},

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -9,6 +9,7 @@ KNOWN_CONFIG_KEYS = DottedDict(
     {
         "database_url": {},
         "database_readonly": {},
+        "standby": {},
         "redis_url": {},
         "piddir": {},
         "user": {},

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -233,11 +233,11 @@ class TestConfiguration:
             }
         )
 
-        save_yaml_config({}, run_init=False)
+        save_yaml_config({"irrd": {"standby": True}}, run_init=False)
         os.kill(os.getpid(), signal.SIGHUP)
         assert list(get_setting("sources_default")) == ["TESTDB2", "TESTDB", "RPKI"]
         assert "Errors found in configuration, continuing with current settings" in caplog.text
-        assert 'Could not find root item "irrd"' in caplog.text
+        assert 'Setting standby can only be set' in caplog.text
 
     def test_load_invalid_config(self, save_yaml_config, tmpdir):
         config = {

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -233,16 +233,16 @@ class TestConfiguration:
             }
         )
 
-        save_yaml_config({"irrd": {"standby": True}}, run_init=False)
+        save_yaml_config({}, run_init=False)
         os.kill(os.getpid(), signal.SIGHUP)
         assert list(get_setting("sources_default")) == ["TESTDB2", "TESTDB", "RPKI"]
         assert "Errors found in configuration, continuing with current settings" in caplog.text
-        assert "Setting standby can only be set" in caplog.text
+        assert 'Could not find root item "irrd"' in caplog.text
 
     def test_load_invalid_config(self, save_yaml_config, tmpdir):
         config = {
             "irrd": {
-                "database_readonly": True,
+                "readonly_standby": True,
                 "piddir": str(tmpdir + "/does-not-exist"),
                 "user": "a",
                 "secret_key": "sssssssssssss",
@@ -379,12 +379,12 @@ class TestConfiguration:
             in str(ce.value)
         )
         assert (
-            "Source TESTDB can not have authoritative, import_source or nrtm_host set when database_readonly"
+            "Source TESTDB can not have authoritative, import_source or nrtm_host set when readonly_standby"
             " is enabled."
             in str(ce.value)
         )
         assert (
-            "Source TESTDB3 can not have authoritative, import_source or nrtm_host set when database_readonly"
+            "Source TESTDB3 can not have authoritative, import_source or nrtm_host set when readonly_standby"
             " is enabled."
             in str(ce.value)
         )

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -237,7 +237,7 @@ class TestConfiguration:
         os.kill(os.getpid(), signal.SIGHUP)
         assert list(get_setting("sources_default")) == ["TESTDB2", "TESTDB", "RPKI"]
         assert "Errors found in configuration, continuing with current settings" in caplog.text
-        assert 'Setting standby can only be set' in caplog.text
+        assert "Setting standby can only be set" in caplog.text
 
     def test_load_invalid_config(self, save_yaml_config, tmpdir):
         config = {

--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -142,10 +142,8 @@ def run_irrd(mirror_frequency: int, config_file_path: str, uid: Optional[int], g
 
     mirror_scheduler = MirrorScheduler()
 
-    preload_manager = None
-    if not get_setting(f"database_readonly"):
-        preload_manager = PreloadStoreManager(name="irrd-preload-store-manager")
-        preload_manager.start()
+    preload_manager = PreloadStoreManager(name="irrd-preload-store-manager")
+    preload_manager.start()
 
     uvicorn_process = ExceptionLoggingProcess(
         target=run_http_server, name="irrd-http-server-listener", args=(config_file_path,)

--- a/irrd/mirroring/jobs.py
+++ b/irrd/mirroring/jobs.py
@@ -1,0 +1,49 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+from irrd.storage.database_handler import DatabaseHandler
+from irrd.storage.preload import Preloader
+
+logger = logging.getLogger(__name__)
+
+
+class TransactionTimePreloadSignaller:
+    """
+    Signal a preload based on the last transaction time.
+    """
+
+    last_time = Optional[datetime]
+
+    def run(self):
+        self.database_handler = DatabaseHandler()
+        self.preloader = Preloader(enable_queries=False)
+
+        try:
+            current_time = self.database_handler.timestamp_last_committed_transaction()
+            if not self.last_time or self.last_time != current_time:
+                self.preloader.signal_reload()
+                logger.debug(
+                    (
+                        f"Signalling preload reload: last transaction completed {current_time}, previous"
+                        f" known last transaction was {self.last_time}"
+                    ),
+                )
+                self.last_time = current_time
+        except Exception as exc:
+            logger.error(
+                (
+                    "An exception occurred while attempting to check transaction timing, signalling preload"
+                    f" reload anyways: {exc}"
+                ),
+                exc_info=exc,
+            )
+            try:
+                self.preloader.signal_reload()
+            except Exception as exc:
+                logger.error(
+                    f"Failed to send preload reload signal: {exc}",
+                    exc_info=exc,
+                )
+        finally:
+            self.database_handler.close()

--- a/irrd/mirroring/jobs.py
+++ b/irrd/mirroring/jobs.py
@@ -13,7 +13,7 @@ class TransactionTimePreloadSignaller:
     Signal a preload based on the last transaction time.
     """
 
-    last_time = Optional[datetime]
+    last_time: Optional[datetime] = None
 
     def run(self):
         self.database_handler = DatabaseHandler()
@@ -22,13 +22,13 @@ class TransactionTimePreloadSignaller:
         try:
             current_time = self.database_handler.timestamp_last_committed_transaction()
             if not self.last_time or self.last_time != current_time:
-                self.preloader.signal_reload()
                 logger.debug(
                     (
                         f"Signalling preload reload: last transaction completed {current_time}, previous"
                         f" known last transaction was {self.last_time}"
                     ),
                 )
+                self.preloader.signal_reload()
                 self.last_time = current_time
         except Exception as exc:
             logger.error(

--- a/irrd/mirroring/mirror_runners_import.py
+++ b/irrd/mirroring/mirror_runners_import.py
@@ -279,10 +279,6 @@ class ROAImportRunner(FileImportRunnerBase):
     in the configuration.
     """
 
-    # API consistency with other importers, source is actually ignored
-    def __init__(self, source=None):
-        pass
-
     def run(self):
         self.database_handler = DatabaseHandler()
 
@@ -354,10 +350,6 @@ class ScopeFilterUpdateRunner:
     This runner does not actually import anything, the scope filter
     is in the configuration.
     """
-
-    # API consistency with other importers, source is actually ignored
-    def __init__(self, source=None):
-        pass
 
     def run(self):
         self.database_handler = DatabaseHandler()

--- a/irrd/mirroring/scheduler.py
+++ b/irrd/mirroring/scheduler.py
@@ -10,6 +10,7 @@ from setproctitle import setproctitle
 
 from irrd.conf import get_setting
 from irrd.conf.defaults import DEFAULT_SOURCE_EXPORT_TIMER, DEFAULT_SOURCE_IMPORT_TIMER
+from irrd.mirroring.jobs import TransactionTimePreloadSignaller
 
 from .mirror_runners_export import SourceExportRunner
 from .mirror_runners_import import (
@@ -74,8 +75,12 @@ class MirrorScheduler:
         self.previous_scopefilter_prefixes = None
         self.previous_scopefilter_asns = None
         self.previous_scopefilter_excluded = None
+        self.transaction_time_preload_signaller = TransactionTimePreloadSignaller()
 
     def run(self) -> None:
+        if get_setting("standby"):
+            self.transaction_time_preload_signaller.run()
+
         if get_setting("database_readonly"):
             return
 

--- a/irrd/mirroring/scheduler.py
+++ b/irrd/mirroring/scheduler.py
@@ -75,13 +75,13 @@ class MirrorScheduler:
         self.previous_scopefilter_prefixes = None
         self.previous_scopefilter_asns = None
         self.previous_scopefilter_excluded = None
+        # This signaller is special in that it does not run in a separate
+        # process and keeps state in the instance.
         self.transaction_time_preload_signaller = TransactionTimePreloadSignaller()
 
     def run(self) -> None:
-        if get_setting("standby"):
+        if get_setting("readonly_standby"):
             self.transaction_time_preload_signaller.run()
-
-        if get_setting("database_readonly"):
             return
 
         if get_setting("rpki.roa_source"):

--- a/irrd/mirroring/scheduler.py
+++ b/irrd/mirroring/scheduler.py
@@ -4,11 +4,11 @@ import multiprocessing
 import signal
 import time
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 
 from setproctitle import setproctitle
 
-from irrd.conf import RPKI_IRR_PSEUDO_SOURCE, get_setting
+from irrd.conf import get_setting
 from irrd.conf.defaults import DEFAULT_SOURCE_EXPORT_TIMER, DEFAULT_SOURCE_IMPORT_TIMER
 
 from .mirror_runners_export import SourceExportRunner
@@ -57,7 +57,7 @@ class ScheduledTaskProcess(multiprocessing.Process):
 
 class MirrorScheduler:
     """
-    Scheduler for mirroring processes.
+    Scheduler for periodic processes, mainly mirroring.
 
     For each time run() is called, will start a process for each mirror database
     unless a process is still running for that database (which is likely to be
@@ -81,7 +81,7 @@ class MirrorScheduler:
 
         if get_setting("rpki.roa_source"):
             import_timer = int(get_setting("rpki.roa_import_timer"))
-            self.run_if_relevant(RPKI_IRR_PSEUDO_SOURCE, ROAImportRunner, import_timer)
+            self.run_if_relevant(None, ROAImportRunner, import_timer)
 
         if get_setting("sources") and any(
             [
@@ -90,10 +90,10 @@ class MirrorScheduler:
             ]
         ):
             import_timer = int(get_setting("route_object_preference.update_timer"))
-            self.run_if_relevant("routepref", RoutePreferenceUpdateRunner, import_timer)
+            self.run_if_relevant(None, RoutePreferenceUpdateRunner, import_timer)
 
         if self._check_scopefilter_change():
-            self.run_if_relevant("scopefilter", ScopeFilterUpdateRunner, 0)
+            self.run_if_relevant(None, ScopeFilterUpdateRunner, 0)
 
         sources_started = 0
         for source in get_setting("sources", {}).keys():
@@ -150,15 +150,23 @@ class MirrorScheduler:
             return True
         return False
 
-    def run_if_relevant(self, source: str, runner_class, timer: int) -> bool:
-        process_name = f"{runner_class.__name__}-{source}"
+    def run_if_relevant(self, source: Optional[str], runner_class, timer: int) -> bool:
+        process_name = runner_class.__name__
+        if source:
+            process_name += f"-{source}"
         current_time = time.time()
         has_expired = (self.last_started_time[process_name] + timer) < current_time
         if not has_expired or process_name in self.processes:
             return False
 
-        logger.debug(f"Started new process {process_name} for mirror import/export for {source}")
-        initiator = runner_class(source=source)
+        kwargs = {}
+        msg = f"Started new scheduled process {process_name}"
+        if source:
+            msg += f"for mirror import/export for {source}"
+            kwargs["source"] = source
+        logger.debug(msg)
+
+        initiator = runner_class(**kwargs)
         process = ScheduledTaskProcess(runner=initiator, name=process_name)
         self.processes[process_name] = process
         process.start()

--- a/irrd/mirroring/tests/test_jobs.py
+++ b/irrd/mirroring/tests/test_jobs.py
@@ -1,0 +1,57 @@
+import datetime
+from unittest.mock import create_autospec
+
+from irrd.storage.database_handler import DatabaseHandler
+from irrd.storage.preload import Preloader
+
+from ...utils.test_utils import flatten_mock_calls
+from ..jobs import TransactionTimePreloadSignaller
+
+
+class TestTransactionTimePreloadSignaller:
+    def test_run(self, monkeypatch):
+        mock_dh = create_autospec(DatabaseHandler)
+        mock_preloader = create_autospec(Preloader)
+
+        monkeypatch.setattr("irrd.mirroring.jobs.DatabaseHandler", lambda: mock_dh)
+        monkeypatch.setattr("irrd.mirroring.jobs.Preloader", lambda enable_queries: mock_preloader)
+
+        mock_dh.timestamp_last_committed_transaction = lambda: datetime.datetime(2023, 1, 1)
+
+        signaller = TransactionTimePreloadSignaller()
+        signaller.run()
+        signaller.run()
+        # Should only have one call
+        assert flatten_mock_calls(mock_preloader) == [["signal_reload", (), {}]]
+
+        mock_preloader.reset_mock()
+        mock_dh.timestamp_last_committed_transaction = lambda: datetime.datetime(2023, 1, 2)
+        signaller.run()
+        assert flatten_mock_calls(mock_preloader) == [["signal_reload", (), {}]]
+
+    def test_fail_database_query(self, monkeypatch, caplog):
+        mock_dh = create_autospec(DatabaseHandler)
+        mock_preloader = create_autospec(Preloader)
+
+        monkeypatch.setattr("irrd.mirroring.jobs.DatabaseHandler", lambda: mock_dh)
+        monkeypatch.setattr("irrd.mirroring.jobs.Preloader", lambda enable_queries: mock_preloader)
+
+        mock_dh.timestamp_last_committed_transaction.side_effect = Exception()
+
+        signaller = TransactionTimePreloadSignaller()
+        signaller.run()
+        assert flatten_mock_calls(mock_preloader) == [["signal_reload", (), {}]]
+        assert "exception occurred" in caplog.text
+
+    def test_fail_preload(self, monkeypatch, caplog):
+        mock_dh = create_autospec(DatabaseHandler)
+        mock_preloader = create_autospec(Preloader)
+
+        monkeypatch.setattr("irrd.mirroring.jobs.DatabaseHandler", lambda: mock_dh)
+        monkeypatch.setattr("irrd.mirroring.jobs.Preloader", lambda enable_queries: mock_preloader)
+
+        mock_preloader.signal_reload.side_effect = Exception()
+
+        signaller = TransactionTimePreloadSignaller()
+        signaller.run()
+        assert "Failed to send" in caplog.text

--- a/irrd/mirroring/tests/test_scheduler.py
+++ b/irrd/mirroring/tests/test_scheduler.py
@@ -307,8 +307,8 @@ class TestScheduledTaskProcess:
 class MockRunner:
     run_sleep = True
 
-    def __init__(self, source):
-        assert source in ["TEST", "TEST2", "TEST3", "TEST4", "RPKI", "scopefilter", "routepref"]
+    def __init__(self, source=None):
+        assert source in ["TEST", "TEST2", "TEST3", "TEST4", None]
 
     def run(self):
         global thread_run_count

--- a/irrd/scripts/expire_journal.py
+++ b/irrd/scripts/expire_journal.py
@@ -83,8 +83,8 @@ def main():  # pragma: no cover
     args = parser.parse_args()
 
     config_init(args.config_file_path)
-    if get_setting("database_readonly"):
-        print("Unable to run, because database_readonly is set")
+    if get_setting("readonly_standby"):
+        print("Unable to run, because readonly_standby is set")
         sys.exit(-1)
 
     try:

--- a/irrd/scripts/irrd_control.py
+++ b/irrd/scripts/irrd_control.py
@@ -20,10 +20,10 @@ from irrd.webui import UI_DEFAULT_DATETIME_FORMAT
 logger = logging.getLogger(__name__)
 
 
-def check_database_readonly(f):
+def check_readonly_standby(f):
     def new_func(*args, **kwargs):
-        if get_setting("database_readonly"):
-            raise click.ClickException("Unable to run this command, because database_readonly is set.")
+        if get_setting("readonly_standby"):
+            raise click.ClickException("Unable to run this command, because readonly_standby is set.")
         return f(*args, **kwargs)
 
     return update_wrapper(new_func, f)
@@ -43,7 +43,7 @@ def cli(config):
 
 @cli.command()
 @click.argument("email")
-@check_database_readonly
+@check_readonly_standby
 @session_provider_manager_sync
 def user_mfa_clear(email, session_provider: ORMSessionProvider):
     """
@@ -92,7 +92,7 @@ def user_mfa_clear(email, session_provider: ORMSessionProvider):
 @cli.command()
 @click.argument("email")
 @click.option("--enable/--disable", default=True)
-@check_database_readonly
+@check_readonly_standby
 @session_provider_manager_sync
 def user_change_override(email: str, enable: bool, session_provider: ORMSessionProvider):
     """

--- a/irrd/scripts/load_database.py
+++ b/irrd/scripts/load_database.py
@@ -72,8 +72,8 @@ def main():  # pragma: no cover
     args = parser.parse_args()
 
     config_init(args.config_file_path)
-    if get_setting("database_readonly"):
-        print("Unable to run, because database_readonly is set")
+    if get_setting("readonly_standby"):
+        print("Unable to run, because readonly_standby is set")
         sys.exit(-1)
 
     sys.exit(load(args.source, args.input_file, args.serial))

--- a/irrd/scripts/mirror_force_reload.py
+++ b/irrd/scripts/mirror_force_reload.py
@@ -36,8 +36,8 @@ def main():  # pragma: no cover
     args = parser.parse_args()
 
     config_init(args.config_file_path)
-    if get_setting("database_readonly"):
-        print("Unable to run, because database_readonly is set")
+    if get_setting("readonly_standby"):
+        print("Unable to run, because readonly_standby is set")
         sys.exit(-1)
 
     set_force_reload(args.source)

--- a/irrd/scripts/rpsl_read.py
+++ b/irrd/scripts/rpsl_read.py
@@ -107,8 +107,8 @@ def main():  # pragma: no cover
     args = parser.parse_args()
 
     config_init(args.config_file_path)
-    if get_setting("database_readonly"):
-        print("Unable to run, because database_readonly is set")
+    if get_setting("readonly_standby"):
+        print("Unable to run, because readonly_standby is set")
         sys.exit(-1)
 
     RPSLParse().main(args.input_file, args.strict_validation, args.database, not args.hide_info)

--- a/irrd/scripts/set_last_modified_auth.py
+++ b/irrd/scripts/set_last_modified_auth.py
@@ -57,8 +57,8 @@ def main():  # pragma: no cover
     args = parser.parse_args()
 
     config_init(args.config_file_path)
-    if get_setting("database_readonly"):
-        print("Unable to run, because database_readonly is set")
+    if get_setting("readonly_standby"):
+        print("Unable to run, because readonly_standby is set")
         sys.exit(-1)
 
     sys.exit(set_last_modified())

--- a/irrd/scripts/tests/test_irrd_control.py
+++ b/irrd/scripts/tests/test_irrd_control.py
@@ -75,13 +75,13 @@ class TestUserMfaClear:
         assert "No user found" in result.output
         assert not smtpd_override.messages
 
-    def test_database_readonly(self, irrd_db_session_with_user, config_override, smtpd_override):
-        config_override({"database_readonly": True})
+    def test_readonly_standby(self, irrd_db_session_with_user, config_override, smtpd_override):
+        config_override({"readonly_standby": True})
 
         runner = CliRunner()
         result = runner.invoke(user_mfa_clear, ["user.email"])
         assert result.exit_code == 1
-        assert "database_readonly" in result.output
+        assert "readonly_standby" in result.output
         assert not smtpd_override.messages
 
 
@@ -162,11 +162,11 @@ class TestUserChangeOverride:
         assert result.exit_code == 1
         assert "has no two-factor" in result.output
 
-    def test_database_readonly(self, irrd_db_session_with_user, config_override):
-        config_override({"database_readonly": True})
+    def test_readonly_standby(self, irrd_db_session_with_user, config_override):
+        config_override({"readonly_standby": True})
         session_provider, user = irrd_db_session_with_user
 
         runner = CliRunner()
         result = runner.invoke(user_change_override, [user.email, "--enable"], input="y")
         assert result.exit_code == 1
-        assert "database_readonly" in result.output
+        assert "readonly_standby" in result.output

--- a/irrd/scripts/update_database.py
+++ b/irrd/scripts/update_database.py
@@ -64,8 +64,8 @@ def main():  # pragma: no cover
     args = parser.parse_args()
 
     config_init(args.config_file_path)
-    if get_setting("database_readonly"):
-        print("Unable to run, because database_readonly is set")
+    if get_setting("readonly_standby"):
+        print("Unable to run, because readonly_standby is set")
         sys.exit(-1)
 
     sys.exit(update(args.source, args.input_file))

--- a/irrd/storage/database_handler.py
+++ b/irrd/storage/database_handler.py
@@ -92,10 +92,10 @@ class DatabaseHandler:
 
         If readonly is True, this instance will expect read queries only.
         No transaction will be started, all queries will use autocommit.
-        Readonly is always true if database_readonly is set in the config.
+        Readonly is always true if readonly_standby is set in the config.
         """
         self.status_tracker = None
-        if get_setting("database_readonly"):
+        if get_setting("readonly_standby"):
             self.readonly = True
         else:
             self.readonly = readonly

--- a/irrd/storage/database_handler.py
+++ b/irrd/storage/database_handler.py
@@ -586,7 +586,7 @@ class DatabaseHandler:
             table.c.prefix,
             table.c.object_text,
         )
-        results = self._connection.execute(stmt)
+        results = self.execute_statement(stmt)
 
         if not self._check_single_row_match(results, user_identifier=f"{rpsl_pk}/{source}"):
             return None
@@ -816,6 +816,10 @@ class DatabaseHandler:
             f"force_reload flag set for {source}, serial synchronisation will be {synchronised_serials} for "
             "current settings, actual reload process wll take place in next scheduled importer run"
         )
+
+    def timestamp_last_committed_transaction(self) -> datetime:
+        result = self.execute_statement("SELECT timestamp FROM pg_last_committed_xact()")
+        return result.fetchone()["timestamp"]
 
     def record_serial_newest_mirror(self, source: str, serial: int) -> None:
         """

--- a/irrd/storage/preload.py
+++ b/irrd/storage/preload.py
@@ -99,7 +99,7 @@ class Preloader:
                 callback=self._load_routes_into_memory, pubsub=self._pubsub, sleep_time=5, daemon=True
             )
             self._pubsub_thread.start()
-            if get_setting("database_readonly"):  # pragma: no cover
+            if get_setting("readonly_standby"):  # pragma: no cover
                 # If this instance is readonly, another IRRd process will be updating
                 # the store, and likely has already done so, meaning we can try to load
                 # from Redis right away instead of waiting for a signal.

--- a/irrd/storage/tests/test_database.py
+++ b/irrd/storage/tests/test_database.py
@@ -96,7 +96,7 @@ class TestDatabaseHandlerLive:
 
         config_override(
             {
-                "database_readonly": True,
+                "readonly_standby": True,
             }
         )
 

--- a/irrd/storage/tests/test_database.py
+++ b/irrd/storage/tests/test_database.py
@@ -215,6 +215,7 @@ class TestDatabaseHandlerLive:
         self.dh.upsert_rpsl_object(rpsl_object_route_v6, JournalEntryOrigin.auth_change, source_serial=43)
 
         self.dh.commit()
+        initial_tx_timestamp = self.dh.timestamp_last_committed_transaction()
         self.dh.refresh_connection()
 
         # There should be two entries with MNT-CORRECT in the db now.
@@ -441,6 +442,8 @@ class TestDatabaseHandlerLive:
         assert not len(list(self.dh.execute_query(RPSLDatabaseQuery().sources(["TEST"]))))
         assert not len(list(self.dh.execute_query(DatabaseStatusQuery().sources(["TEST"]))))
         assert len(list(self.dh.execute_query(RPSLDatabaseQuery().sources(["TEST2"])))) == 1
+
+        assert self.dh.timestamp_last_committed_transaction() > initial_tx_timestamp
 
         self.dh.close()
 


### PR DESCRIPTION
This is a sync mechanism specific for authoritative deployments for providing standby and query-only secondaries. Particularly when mixing the two.

With #617, there is a lot of potential data in PostgreSQL that will not be included in NRTM. NRTM was always a poor solution for standby instances, with `nrtm_access_list_unfiltered` as a hack on top, and potential loss of journal data and any suppressed objects. PostgreSQL replication fixes a lot of these issues, including even retaining serials. However, preloaded data will go out of date on standby instances. Redis replication is not a full fix, as some of the preloaded data is in memory in worker processes.

PostgreSQL does support triggers on a replica as noted in #656, but not when using WAL streaming, which is the only reasonable option here, as logical streaming breaks sequences and seems to have issues with upserts. The idea of monitoring for records where `updated` is higher than the last check is insufficient, because it does not catch row deletions or certain suppression state changes.

Best option: `select timestamp from pg_last_committed_xact()`. This does not allow us to filter for object types. However, considering route(6) and soon as-set are preloaded, many transactions will require pre-load store updates. There will therefore be additional overhead, but at the benefit of always being sure preloaded data gets updated. Caveat: the timestamp is not database-specific, so does not work well when running multiple databases. But these seems like an acceptable cost for people who need to run hot standby servers and is a fairly solid fix for the long standing difficulties in these setups.

The suppression status will be replicated as well, i.e. the `!f` queries will also work and suppressed objects are not lost during a switchover. However, the local config state shown in `!J` may not be consistent. This needs to be reflected in the docs. Also, during switchover, which requires a restart anyways, PGP keys have to be reimported into the local keychain. Hard and not worthwhile to do while running as standby.

- [x] Check if suppression config can be enabled even though it has no direct effect on the standby.
- [x] Add poller process
- [x] New docs
- [x] Deprecate unfiltered NRTM
- [x] track_commit_timestamp must be enabled
- [x] How to handle if track_commit_timestamp is not set
- [x] Document and verify new standby setting
- [x] Test in real setup
- [x] hot_standby_feedback
- [x] Anything in the query resolver that checks suppression status?
- [x] doc: IP access lists external failover