### PR TITLE
fix compatibility with asgiref >=3.7.0

### DIFF
--- a/irrd/server/graphql/schema_builder.py
+++ b/irrd/server/graphql/schema_builder.py
@@ -31,32 +31,32 @@ def build_executable_schema():
     """
     schema = SchemaGenerator()
 
-    schema.rpsl_object_type.set_type_resolver(sta(resolve_rpsl_object_type, False))
-    schema.rpsl_contact_union_type.set_type_resolver(sta(resolve_rpsl_object_type, False))
+    schema.rpsl_object_type.set_type_resolver(sta(resolve_rpsl_object_type, thread_sensitive=False))
+    schema.rpsl_contact_union_type.set_type_resolver(sta(resolve_rpsl_object_type, thread_sensitive=False))
 
-    schema.query_type.set_field("rpslObjects", sta(resolve_rpsl_objects, False))
-    schema.query_type.set_field("databaseStatus", sta(resolve_database_status, False))
-    schema.query_type.set_field("asnPrefixes", sta(resolve_asn_prefixes, False))
-    schema.query_type.set_field("asSetPrefixes", sta(resolve_as_set_prefixes, False))
-    schema.query_type.set_field("recursiveSetMembers", sta(resolve_recursive_set_members, False))
+    schema.query_type.set_field("rpslObjects", sta(resolve_rpsl_objects, thread_sensitive=False))
+    schema.query_type.set_field("databaseStatus", sta(resolve_database_status, thread_sensitive=False))
+    schema.query_type.set_field("asnPrefixes", sta(resolve_asn_prefixes, thread_sensitive=False))
+    schema.query_type.set_field("asSetPrefixes", sta(resolve_as_set_prefixes, thread_sensitive=False))
+    schema.query_type.set_field("recursiveSetMembers", sta(resolve_recursive_set_members, thread_sensitive=False))
 
-    schema.rpsl_object_type.set_field("mntByObjs", sta(resolve_rpsl_object_mnt_by_objs, False))
-    schema.rpsl_object_type.set_field("journal", sta(resolve_rpsl_object_journal, False))
+    schema.rpsl_object_type.set_field("mntByObjs", sta(resolve_rpsl_object_mnt_by_objs, thread_sensitive=False))
+    schema.rpsl_object_type.set_field("journal", sta(resolve_rpsl_object_journal, thread_sensitive=False))
     for object_type in schema.object_types:
         if "adminCObjs" in schema.graphql_types[object_type.name]:
-            object_type.set_field("adminCObjs", sta(resolve_rpsl_object_adminc_objs, False))
+            object_type.set_field("adminCObjs", sta(resolve_rpsl_object_adminc_objs, thread_sensitive=False))
     for object_type in schema.object_types:
         if "techCObjs" in schema.graphql_types[object_type.name]:
-            object_type.set_field("techCObjs", sta(resolve_rpsl_object_techc_objs, False))
+            object_type.set_field("techCObjs", sta(resolve_rpsl_object_techc_objs, thread_sensitive=False))
     for object_type in schema.object_types:
         if "mbrsByRefObjs" in schema.graphql_types[object_type.name]:
-            object_type.set_field("mbrsByRefObjs", sta(resolve_rpsl_object_members_by_ref_objs, False))
+            object_type.set_field("mbrsByRefObjs", sta(resolve_rpsl_object_members_by_ref_objs, thread_sensitive=False))
     for object_type in schema.object_types:
         if "memberOfObjs" in schema.graphql_types[object_type.name]:
-            object_type.set_field("memberOfObjs", sta(resolve_rpsl_object_member_of_objs, False))
+            object_type.set_field("memberOfObjs", sta(resolve_rpsl_object_member_of_objs, thread_sensitive=False))
     for object_type in schema.object_types:
         if "membersObjs" in schema.graphql_types[object_type.name]:
-            object_type.set_field("membersObjs", sta(resolve_rpsl_object_members_objs, False))
+            object_type.set_field("membersObjs", sta(resolve_rpsl_object_members_objs, thread_sensitive=False))
 
     @schema.asn_scalar_type.value_parser
     def parse_asn_scalar(value):


### PR DESCRIPTION
sync_to_async no longer accepts thread_sensitive as an unnamed parameter. https://github.com/django/asgiref/commit/72f45c5feb158f71c5b5fb337e323c7bacd6c7b3