### PR TITLE
Add configurable NRTM response header

### DIFF
--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -717,10 +717,12 @@ Sources
   and will take that into account.
   |br| **Default**: not defined, no limits on NRTM query size.
   |br| **Change takes effect**: after SIGHUP, upon next request.
-* ``sources.{name}.nrtm_response_header``: the content in NRTM response
-  header. This can have multiple lines.  When adding this to the configuration, 
+* ``sources.{name}.nrtm_response_header``: an additional NRTM response
+  header, added as a comment to all NRTM responses for this source.
+  IRRD will prepend the lines with ``%`` to mark them as comments.
+  This can have multiple lines.  When adding this to the configuration,
   use the `|` style to preserve newlines.
-  |br| **Default**: not defined.
+  |br| **Default**: not defined, no additional header added.
   |br| **Change takes effect**: after SIGHUP, upon next request.
 * ``sources.{name}.strict_import_keycert_objects``: a setting used when
   migrating authoritative data that may contain `key-cert` objects.

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -717,6 +717,11 @@ Sources
   and will take that into account.
   |br| **Default**: not defined, no limits on NRTM query size.
   |br| **Change takes effect**: after SIGHUP, upon next request.
+* ``sources.{name}.nrtm_response_header``: the content in NRTM response
+  header. This can have multiple lines.  When adding this to the configuration, 
+  use the `|` style to preserve newlines.
+  |br| **Default**: not defined.
+  |br| **Change takes effect**: after SIGHUP, upon next request.
 * ``sources.{name}.strict_import_keycert_objects``: a setting used when
   migrating authoritative data that may contain `key-cert` objects.
   See the :doc:`data migration guide </admins/availability-and-migration>`

--- a/docs/releases/4.4.0.rst
+++ b/docs/releases/4.4.0.rst
@@ -103,6 +103,9 @@ Other changes
   resolving. This was already possible in GraphQL queries.
 * The ``-q`` whois flag was added to query available serial
   ranges in a RIPE format.
+* The ``sources.{name}.nrtm_response_header`` setting was added, to add
+  an additional response header comment to all NRTM responses,
+  configured per source.
 * A ``compatibility.asdot_queries`` setting was added, which allows
   the use of the (long deprecated) asdot format in origin queries.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -63,6 +63,7 @@ preloaded
 preloader
 preloading
 preloads
+prepend
 pubsub
 py
 Rajiv

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -99,6 +99,7 @@ KNOWN_SOURCES_KEYS = {
     "nrtm_access_list",
     "nrtm_access_list_unfiltered",
     "nrtm_query_serial_range_limit",
+    "nrtm_response_header",
     "strict_import_keycert_objects",
     "rpki_excluded",
     "scopefilter_excluded",

--- a/irrd/mirroring/nrtm_generator.py
+++ b/irrd/mirroring/nrtm_generator.py
@@ -1,3 +1,4 @@
+import textwrap
 from typing import Optional
 
 from irrd.conf import get_setting
@@ -82,7 +83,8 @@ class NRTMGenerator:
 
         output = []
         if get_setting(f"sources.{source}.nrtm_response_header"):
-            output.append(get_setting(f"sources.{source}.nrtm_response_header"))
+            header = textwrap.indent(get_setting(f"sources.{source}.nrtm_response_header"), "%")
+            output.append(header)
 
         output.append(f"%START Version: {version} {source} {serial_start_requested}-{serial_end_display}\n")
 

--- a/irrd/mirroring/nrtm_generator.py
+++ b/irrd/mirroring/nrtm_generator.py
@@ -80,7 +80,11 @@ class NRTMGenerator:
             .serial_nrtm_range(serial_start_requested, serial_end_requested)
         )
 
-        output = [f"%START Version: {version} {source} {serial_start_requested}-{serial_end_display}\n"]
+        output = []
+        if get_setting(f"sources.{source}.nrtm_response_header"):
+            output.append(get_setting(f"sources.{source}.nrtm_response_header"))
+
+        output.append(f"%START Version: {version} {source} {serial_start_requested}-{serial_end_display}\n")
 
         for operation in database_handler.execute_query(q):
             operation_str = operation["operation"].value

--- a/irrd/mirroring/tests/test_nrtm_generator.py
+++ b/irrd/mirroring/tests/test_nrtm_generator.py
@@ -249,7 +249,8 @@ class TestNRTMGenerator:
                 "sources": {
                     "TEST": {
                         "keep_journal": True,
-                        "nrtm_response_header": "%NRTM response header",
+                        "nrtm_response_header": """NRTM response header line1
+NRTM response header line2""",
                     }
                 }
             }
@@ -258,7 +259,8 @@ class TestNRTMGenerator:
         result = generator.generate("TEST", "3", 110, 190, mock_dh)
 
         assert result == textwrap.dedent("""
-        %NRTM response header
+        %NRTM response header line1
+        %NRTM response header line2
         %START Version: 3 TEST 110-190
 
         ADD 120

--- a/irrd/mirroring/tests/test_nrtm_generator.py
+++ b/irrd/mirroring/tests/test_nrtm_generator.py
@@ -249,7 +249,7 @@ class TestNRTMGenerator:
                 "sources": {
                     "TEST": {
                         "keep_journal": True,
-                        "nrtm_response_header": "%NRTM response header"
+                        "nrtm_response_header": "%NRTM response header",
                     }
                 }
             }

--- a/irrd/mirroring/tests/test_nrtm_generator.py
+++ b/irrd/mirroring/tests/test_nrtm_generator.py
@@ -241,3 +241,33 @@ class TestNRTMGenerator:
         object 2 🌈
 
         %END TEST""").strip()
+
+    def test_nrtm_response_header(self, prepare_generator, config_override):
+        generator, mock_dh = prepare_generator
+        config_override(
+            {
+                "sources": {
+                    "TEST": {
+                        "keep_journal": True,
+                        "nrtm_response_header": "%NRTM response header"
+                    }
+                }
+            }
+        )
+
+        result = generator.generate("TEST", "3", 110, 190, mock_dh)
+
+        assert result == textwrap.dedent("""
+        %NRTM response header
+        %START Version: 3 TEST 110-190
+
+        ADD 120
+
+        object 1 🦄
+        auth: CRYPT-PW DummyValue  # Filtered for security
+
+        DEL 180
+
+        object 2 🌈
+
+        %END TEST""").strip()


### PR DESCRIPTION
Allow user to add a customised header in NRTM response. 
```
%<Header>

%START Version: 3 APNIC 11164129-11164129

...

%END APNIC
```