### PR TITLE
Add ripe -q flag

### DIFF
--- a/docs/releases/4.4.0.rst
+++ b/docs/releases/4.4.0.rst
@@ -101,6 +101,8 @@ Other changes
 -------------
 * The ``!e`` whois command was added to exclude sets from recursive
   resolving. This was already possible in GraphQL queries.
+* The ``-q`` whois flag was added to query available serial
+  ranges in a RIPE format.
 * A ``compatibility.asdot_queries`` setting was added, which allows
   the use of the (long deprecated) asdot format in origin queries.
 

--- a/docs/users/queries/whois.rst
+++ b/docs/users/queries/whois.rst
@@ -202,6 +202,7 @@ The queries are:
   than ``-i origin``, as the former benefit from preloading. However, the
   ``-i`` queries are more flexible.
 * ``-t <object-class>`` returns the template for a particular object class.
+* ``-q sources`` returns the serial range for each source.
 * ``-g`` returns an NRTM response, used for mirroring. See the
   :doc:`mirroring documentation </users/mirroring>`.
 * Any other (part of) the query is interpreted as a free text search:


### PR DESCRIPTION
Support RIPE `-q sources` query flag

```
% telnet whois.ripe.net 4444                                                         
-q sources
RIPE:3:X:2278326-56950189
RIPE-NONAUTH:3:X:2278326-56950189

Connection closed by foreign host.
```