### PR TITLE
Fix logging issues in PyPy

### DIFF
--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -134,7 +134,10 @@ def run_irrd(mirror_frequency: int, config_file_path: str, uid: Optional[int], g
     set_traceback_handler()
 
     whois_process = ExceptionLoggingProcess(
-        target=start_whois_server, name="irrd-whois-server-listener", kwargs={"uid": uid, "gid": gid}
+        config_file_path=config_file_path,
+        target=start_whois_server,
+        name="irrd-whois-server-listener",
+        kwargs={"uid": uid, "gid": gid},
     )
     whois_process.start()
     if uid and gid:
@@ -142,11 +145,14 @@ def run_irrd(mirror_frequency: int, config_file_path: str, uid: Optional[int], g
 
     mirror_scheduler = MirrorScheduler()
 
-    preload_manager = PreloadStoreManager(name="irrd-preload-store-manager")
+    preload_manager = PreloadStoreManager(config_file_path=config_file_path, name="irrd-preload-store-manager")
     preload_manager.start()
 
     uvicorn_process = ExceptionLoggingProcess(
-        target=run_http_server, name="irrd-http-server-listener", args=(config_file_path,)
+        config_file_path=config_file_path,
+        target=run_http_server,
+        name="irrd-http-server-listener",
+        args=(config_file_path,),
     )
     uvicorn_process.start()
 

--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -145,7 +145,9 @@ def run_irrd(mirror_frequency: int, config_file_path: str, uid: Optional[int], g
 
     mirror_scheduler = MirrorScheduler()
 
-    preload_manager = PreloadStoreManager(config_file_path=config_file_path, name="irrd-preload-store-manager")
+    preload_manager = PreloadStoreManager(
+        config_file_path=config_file_path, name="irrd-preload-store-manager"
+    )
     preload_manager.start()
 
     uvicorn_process = ExceptionLoggingProcess(

--- a/irrd/storage/tests/test_preload.py
+++ b/irrd/storage/tests/test_preload.py
@@ -52,7 +52,7 @@ def mock_redis_keys(monkeypatch, config_override):
 
 class TestPreloading:
     def test_load_reload_thread_management(self, mock_preload_updater, mock_redis_keys):
-        preload_manager = PreloadStoreManager()
+        preload_manager = PreloadStoreManager(config_file_path=None)
 
         preload_manager_thread = threading.Thread(target=preload_manager.main, daemon=True)
         preload_manager_thread.start()
@@ -104,7 +104,7 @@ class TestPreloading:
 
     def test_set_members(self, mock_redis_keys):
         preloader = Preloader()
-        preload_manager = PreloadStoreManager()
+        preload_manager = PreloadStoreManager(config_file_path=None)
 
         # Wait for the preloader instance to start listening on pubsub
         time.sleep(1)
@@ -150,7 +150,7 @@ class TestPreloading:
 
     def test_routes_for_origins(self, mock_redis_keys):
         preloader = Preloader()
-        preload_manager = PreloadStoreManager()
+        preload_manager = PreloadStoreManager(config_file_path=None)
 
         # Wait for the preloader instance to start listening on pubsub
         time.sleep(1)

--- a/irrd/utils/process_support.py
+++ b/irrd/utils/process_support.py
@@ -9,6 +9,8 @@ from multiprocessing import Process
 
 from setproctitle import getproctitle
 
+from irrd.conf import config_init
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,8 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 class ExceptionLoggingProcess(Process):  # pragma: no cover
+    def __init__(self, config_file_path: str, *args, **kwargs):
+        self.config_file_path = config_file_path
+        super().__init__(*args, **kwargs)
+
     def run(self) -> None:
         try:
+            # Reinitialise the config to reopen logger file handles in PyPy
+            config_init(self.config_file_path)
             super().run()
         except Exception as e:
             logger.critical(


### PR DESCRIPTION
In PyPy, the file descriptors for log files can break after fork. This reinitialises the config to renew them.
