### PR TITLE
[4.2.x] Fix source filter in mbrs-by-ref lookup

### DIFF
--- a/irrd/server/query_resolver.py
+++ b/irrd/server/query_resolver.py
@@ -309,6 +309,7 @@ class QueryResolver:
             # is set to ANY.
             query_object_class = ['route', 'route6'] if object_class == 'route-set' else ['aut-num']
             query = self._prepare_query(column_names=columns).object_classes(query_object_class)
+            query = query.sources([result["source"]])
             query = query.lookup_attrs_in(['member-of'], [rpsl_pk])
 
             if 'ANY' not in [m.strip().upper() for m in mbrs_by_ref]:

--- a/irrd/server/tests/test_query_resolver.py
+++ b/irrd/server/tests/test_query_resolver.py
@@ -550,6 +550,7 @@ class TestQueryResolver:
 
             ['sources', (['TEST1', 'TEST2'],), {}],
             ['object_classes', (['route', 'route6'],), {}],
+            ["sources", (["TEST1"],), {}],
             ['lookup_attrs_in', (['member-of'], ['RRS-TEST']), {}],
             ['lookup_attrs_in', (['mnt-by'], ['MNT-TEST']), {}],
         ]
@@ -567,6 +568,7 @@ class TestQueryResolver:
 
             ['sources', (['TEST1', 'TEST2'],), {}],
             ['object_classes', (['route', 'route6'],), {}],
+            ["sources", (["TEST1"],), {}],
             ['lookup_attrs_in', (['member-of'], ['RRS-TEST']), {}],
         ]
 


### PR DESCRIPTION
(cherry pick of 3c36c55ab9ce5432e6a0d99dd9a930400e604a86 from 4.3.x)