### PR TITLE
Move secret key to autogenerated value in DB

### DIFF
--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -44,7 +44,6 @@ This sample shows most configuration options
         user: irrd
         group: irrd
         # required, but no default included for safety
-        secret_key: null
 
         access_lists:
             http_database_status:
@@ -228,14 +227,6 @@ General settings
   :ref:`an HTTPS proxy <deployment-https>` in front. Therefore, there is no
   need for IRRd to bind to port 80 or 443.
   |br| **Default**: not defined, IRRd does not drop privileges.
-  |br| **Change takes effect**: after full IRRd restart.
-* ``secret_key``: a random secret string. **The secrecy of this key protects
-  all web authentication.** If rotated, all sessions and tokens in emails
-  are invalidated, requiring users to log in or request new password
-  reset links. Rotation will **not** invalidate existing user passwords
-  (only reset links), second factor authentication, or API tokens.
-  Minimum 30 characters.
-  |br| **Default**: not defined, but required.
   |br| **Change takes effect**: after full IRRd restart.
 
 

--- a/docs/releases/4.4.0.rst
+++ b/docs/releases/4.4.0.rst
@@ -45,14 +45,11 @@ interface to submit in the same format as email, by including the
 For full details and benefits, see the
 :doc:`web interface and internal authentication documentation </admins/webui/>`
 
-This new feature adds two new required settings, with no default set:
-
-* ``secret_key``, which must be a random secret string, used to protect
-  session data and tokens in emails.
-* ``server.http.url``, which must be the external URL on which users will
-  reach the IRRD instance, used for WebAuthn second factor authentication.
-  This must match the URL as seen from the browser's perspective,
-  and changing it will invalidate all WebAuthn tokens.
+This new feature adds one new required setting: ``server.http.url``,
+which must be the external URL on which users will
+reach the IRRD instance, used for WebAuthn second factor authentication.
+This must match the URL as seen from the browser's perspective,
+and changing it will invalidate all WebAuthn tokens.
 
 
 New recommendations on availability and replication

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -25,7 +25,6 @@ ROUTEPREF_IMPORT_TIME = 3600
 AUTH_SET_CREATION_COMMON_KEY = "COMMON"
 SOCKET_DEFAULT_TIMEOUT = 30
 RPSL_MNTNER_AUTH_INTERNAL = "IRRD-INTERNAL-AUTH"
-MIN_SECRET_KEY_LENGTH = 30
 
 
 LOGGING = {
@@ -259,11 +258,6 @@ class Configuration:
 
         if not self._check_is_str(config, "piddir") or not os.path.isdir(config["piddir"]):
             errors.append("Setting piddir is required and must point to an existing directory.")
-
-        if not self._check_is_str(config, "secret_key") or len(config["secret_key"]) < MIN_SECRET_KEY_LENGTH:
-            errors.append(
-                f"Setting secret_key is required and must be at least {MIN_SECRET_KEY_LENGTH} characters."
-            )
 
         if not str(config.get("route_object_preference.update_timer", "0")).isnumeric():
             errors.append("Setting route_object_preference.update_timer must be a number.")

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -12,7 +12,6 @@ KNOWN_CONFIG_KEYS = DottedDict(
         "piddir": {},
         "user": {},
         "group": {},
-        "secret_key": {},
         "server": {
             "http": {
                 "interface": {},

--- a/irrd/conf/test_conf.py
+++ b/irrd/conf/test_conf.py
@@ -60,7 +60,6 @@ class TestConfiguration:
                 "database_url": "db-url",
                 "redis_url": "redis-url",
                 "piddir": str(tmpdir),
-                "secret_key": "sssssssssssssssssssssssssssssss",
                 "server": {"http": {"url": "https://example.com/"}},
                 "email": {"from": "example@example.com", "smtp": "192.0.2.1"},
                 "route_object_preference": {
@@ -177,7 +176,6 @@ class TestConfiguration:
                 "database_url": "db-url",
                 "redis_url": "redis-url",
                 "piddir": str(tmpdir),
-                "secret_key": "sssssssssssssssssssssssssssssss",
                 "server": {"http": {"url": "https://example.com/"}},
                 "email": {"from": "example@example.com", "smtp": "192.0.2.1"},
                 "rpki": {
@@ -200,7 +198,6 @@ class TestConfiguration:
                     "database_url": "db-url",
                     "redis_url": "redis-url",
                     "piddir": str(tmpdir),
-                    "secret_key": "sssssssssssssssssssssssssssssss",
                     "server": {"http": {"url": "https://example.com/"}},
                     "email": {"from": "example@example.com", "smtp": "192.0.2.1"},
                     "access_lists": {
@@ -248,7 +245,6 @@ class TestConfiguration:
                 "readonly_standby": True,
                 "piddir": str(tmpdir + "/does-not-exist"),
                 "user": "a",
-                "secret_key": "sssssssssssss",
                 "server": {
                     "whois": {
                         "access_list": "doesnotexist",
@@ -343,7 +339,6 @@ class TestConfiguration:
         assert "Setting database_url is required." in str(ce.value)
         assert "Setting redis_url is required." in str(ce.value)
         assert "Setting piddir is required and must point to an existing directory." in str(ce.value)
-        assert "Setting secret_key is required and must be at least 30 characters." in str(ce.value)
         assert "Setting email.from is required and must be an email address." in str(ce.value)
         assert "Setting email.smtp is required." in str(ce.value)
         assert "Setting email.footer must be a string, if defined." in str(ce.value)

--- a/irrd/integration_tests/run.py
+++ b/irrd/integration_tests/run.py
@@ -834,7 +834,6 @@ class TestIntegration:
 
         base_config = {
             "irrd": {
-                "secret_key": "secretsecretsecretsecretsecretsecretsecretsecretsecretsecret",
                 "access_lists": {"localhost": ["::/32", "127.0.0.1"]},
                 "server": {
                     "http": {

--- a/irrd/server/http/app.py
+++ b/irrd/server/http/app.py
@@ -34,9 +34,9 @@ from irrd.server.http.event_stream import (
 )
 from irrd.storage.database_handler import DatabaseHandler
 from irrd.storage.preload import Preloader
-from irrd.utils.misc import secret_key_derive
 from irrd.utils.process_support import memory_trim, set_traceback_handler
 from irrd.webui.auth.users import auth_middleware
+from irrd.webui.helpers import secret_key_derive
 from irrd.webui.routes import UI_ROUTES
 
 logger = logging.getLogger(__name__)

--- a/irrd/storage/alembic/versions/2353e60e63f8_add_setting.py
+++ b/irrd/storage/alembic/versions/2353e60e63f8_add_setting.py
@@ -1,0 +1,29 @@
+"""add_setting
+
+Revision ID: 2353e60e63f8
+Revises: 50d1a0ef58cb
+Create Date: 2023-08-17 11:40:56.122469
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2353e60e63f8"
+down_revision = "50d1a0ef58cb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "setting",
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("value", sa.String(), nullable=True),
+        sa.Column("created", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("name"),
+    )
+
+
+def downgrade():
+    op.drop_table("setting")

--- a/irrd/storage/models.py
+++ b/irrd/storage/models.py
@@ -49,6 +49,23 @@ class AuthoritativeChangeOrigin(enum.Enum):
 Base = declarative_base()
 
 
+class Setting(Base):  # type: ignore
+    """
+    SQLAlchemy ORM object for settings stored in the DB.
+    Only intended for internal IRRD state, not admin-modified settings.
+    """
+
+    __tablename__ = "setting"
+
+    name = sa.Column(sa.String, primary_key=True)
+    value = sa.Column(sa.String)
+
+    created = sa.Column(sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False)
+
+    def __repr__(self):
+        return f"<Setting/{self.name}>"
+
+
 class RPSLDatabaseObject(Base):  # type: ignore
     """
     SQLAlchemy ORM object for RPSL database objects.

--- a/irrd/utils/misc.py
+++ b/irrd/utils/misc.py
@@ -1,8 +1,5 @@
-import hashlib
 import itertools
 from typing import Iterable
-
-from irrd.conf import get_setting
 
 
 def chunked_iterable(iterable: Iterable, size: int) -> Iterable:
@@ -15,13 +12,3 @@ def chunked_iterable(iterable: Iterable, size: int) -> Iterable:
         if not chunk:
             break
         yield chunk
-
-
-def secret_key_derive(scope: str):
-    """
-    Return the secret key for a particular scope.
-    This is derived from the scope, an otherwise meaningless string,
-    and the user configured secret key.
-    """
-    key_base = scope.encode("utf-8") + get_setting("secret_key").encode("utf-8")
-    return str(hashlib.sha512(key_base).hexdigest())

--- a/irrd/utils/tests/test_misc.py
+++ b/irrd/utils/tests/test_misc.py
@@ -1,11 +1,6 @@
-from ..misc import chunked_iterable, secret_key_derive
+from ..misc import chunked_iterable
 
 
 def test_chunked_iterable():
     inp = range(10)
     assert list(chunked_iterable(inp, 3)) == [(0, 1, 2), (3, 4, 5), (6, 7, 8), (9,)]
-
-
-def test_secret_key_derive(config_override):
-    config_override({"secret_key": "secret"})
-    assert secret_key_derive("scope").startswith("eeae975812")

--- a/irrd/webui/auth/users.py
+++ b/irrd/webui/auth/users.py
@@ -23,7 +23,7 @@ from zxcvbn import zxcvbn
 
 from irrd.storage.models import AuthUser
 from irrd.storage.orm_provider import ORMSessionProvider
-from irrd.utils.misc import secret_key_derive
+from irrd.webui.helpers import secret_key_derive
 
 logger = logging.getLogger(__name__)
 

--- a/irrd/webui/tests/test_helpers.py
+++ b/irrd/webui/tests/test_helpers.py
@@ -1,0 +1,8 @@
+from irrd.webui.helpers import secret_key_derive
+
+
+def test_secret_key_derive(irrd_db):
+    key1 = secret_key_derive("scope")
+    assert key1 == secret_key_derive("scope")
+    key2 = secret_key_derive("scope2")
+    assert key1 != key2


### PR DESCRIPTION
Having the secret key in the config is risky, as operators are more likely to leak it by accident. This moves it to the DB, and auto-generates it if there is no existing value.
