### PR TITLE
Actually fix PyPy logging issues (ref #827)

### DIFF
--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -134,10 +134,7 @@ def run_irrd(mirror_frequency: int, config_file_path: str, uid: Optional[int], g
     set_traceback_handler()
 
     whois_process = ExceptionLoggingProcess(
-        config_file_path=config_file_path,
-        target=start_whois_server,
-        name="irrd-whois-server-listener",
-        kwargs={"uid": uid, "gid": gid},
+        target=start_whois_server, name="irrd-whois-server-listener", kwargs={"uid": uid, "gid": gid}
     )
     whois_process.start()
     if uid and gid:
@@ -145,16 +142,11 @@ def run_irrd(mirror_frequency: int, config_file_path: str, uid: Optional[int], g
 
     mirror_scheduler = MirrorScheduler()
 
-    preload_manager = PreloadStoreManager(
-        config_file_path=config_file_path, name="irrd-preload-store-manager"
-    )
+    preload_manager = PreloadStoreManager(name="irrd-preload-store-manager")
     preload_manager.start()
 
     uvicorn_process = ExceptionLoggingProcess(
-        config_file_path=config_file_path,
-        target=run_http_server,
-        name="irrd-http-server-listener",
-        args=(config_file_path,),
+        target=run_http_server, name="irrd-http-server-listener", args=(config_file_path,)
     )
     uvicorn_process.start()
 

--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -53,6 +53,9 @@ def main():
     mirror_frequency = int(os.environ.get("IRRD_SCHEDULER_TIMER_OVERRIDE", 15))
 
     daemon_kwargs = {
+        # by default we set detach_process to true to avoid #848,
+        # the python-daemon default of None does not suffice
+        "detach_process": True,
         "umask": 0o022,
     }
     if args.foreground:

--- a/irrd/storage/tests/test_preload.py
+++ b/irrd/storage/tests/test_preload.py
@@ -52,7 +52,7 @@ def mock_redis_keys(monkeypatch, config_override):
 
 class TestPreloading:
     def test_load_reload_thread_management(self, mock_preload_updater, mock_redis_keys):
-        preload_manager = PreloadStoreManager(config_file_path=None)
+        preload_manager = PreloadStoreManager()
 
         preload_manager_thread = threading.Thread(target=preload_manager.main, daemon=True)
         preload_manager_thread.start()
@@ -104,7 +104,7 @@ class TestPreloading:
 
     def test_set_members(self, mock_redis_keys):
         preloader = Preloader()
-        preload_manager = PreloadStoreManager(config_file_path=None)
+        preload_manager = PreloadStoreManager()
 
         # Wait for the preloader instance to start listening on pubsub
         time.sleep(1)
@@ -150,7 +150,7 @@ class TestPreloading:
 
     def test_routes_for_origins(self, mock_redis_keys):
         preloader = Preloader()
-        preload_manager = PreloadStoreManager(config_file_path=None)
+        preload_manager = PreloadStoreManager()
 
         # Wait for the preloader instance to start listening on pubsub
         time.sleep(1)

--- a/irrd/utils/process_support.py
+++ b/irrd/utils/process_support.py
@@ -9,8 +9,6 @@ from multiprocessing import Process
 
 from setproctitle import getproctitle
 
-from irrd.conf import config_init
-
 logger = logging.getLogger(__name__)
 
 
@@ -18,14 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExceptionLoggingProcess(Process):  # pragma: no cover
-    def __init__(self, config_file_path: str, *args, **kwargs):
-        self.config_file_path = config_file_path
-        super().__init__(*args, **kwargs)
-
     def run(self) -> None:
         try:
-            # Reinitialise the config to reopen logger file handles in PyPy
-            config_init(self.config_file_path)
             super().run()
         except Exception as e:
             logger.critical(


### PR DESCRIPTION
This is the proper fix for https://github.com/irrdnet/irrd/pull/827, as that issue was not completely fixed with that change. The issue seems to be caused by the socket.fromfd() call in https://pagure.io/python-daemon/blob/main/f/daemon/daemon.py#_765, which checks whether the process runs under superserver when detach_process=None. We skip this check now by always setting it to True.

The apparent side effect seems to cause confusion in file descriptor handling, where the FD that used to be the log file becomes switched around with others. E.g. in the preloader, it could get mixed up with the Redis socket, causing writes to the supposed log file FD to be sent to Redis instead. Checks with strace confirm this, as well as tcpdumps of Redis traffic. The reasons for this issue, or why it only occurs on PyPy, are a mystery.

[Issue created in python-daemon](https://pagure.io/python-daemon/issue/83) but this workaround should suffice for now.

Filtered strace sample, note the two log lines:
```
[pid 71444] write(3</var/log/irrd.log>, "2023-08-17 18:47:25,237 irrd[69755]: [irrd.storage.preload#DEBUG] Starting preload store update from thread <PreloadUpdater(Thread-2, started daemon 140457683707584)>\n", 167) = 167
[pid 71444] getpid()                    = 69755
[pid 71444] getpid()                    = 69755
[pid 71444] fcntl(3</var/log/irrd.log>, F_GETFL) = 0x8401 (flags O_WRONLY|O_APPEND|O_LARGEFILE)
[pid 71444] fcntl(3</var/log/irrd.log>, F_SETFL, O_WRONLY|O_APPEND|O_NONBLOCK|O_LARGEFILE) = 0
[pid 71444] fcntl(3</var/log/irrd.log>, F_GETFL) = 0x8c01 (flags O_WRONLY|O_APPEND|O_NONBLOCK|O_LARGEFILE)
[pid 71444] fcntl(3</var/log/irrd.log>, F_SETFL, O_WRONLY|O_APPEND|O_LARGEFILE) = 0
[pid 71444] getpid()                    = 69755
[pid 71444] shutdown(3</var/log/irrd.log>, SHUT_RDWR) = -1 ENOTSOCK (Socket operation on non-socket)
[pid 71444] close(3</var/log/irrd.log>) = 0
[pid 71444] newfstatat(AT_FDCWD</>, "/etc/nsswitch.conf", {st_mode=S_IFREG|0644, st_size=359, ...}, 0) = 0
[pid 71444] newfstatat(AT_FDCWD</>, "/etc/resolv.conf", {st_mode=S_IFREG|0644, st_size=45, ...}, 0) = 0
[pid 71444] rt_sigprocmask(SIG_BLOCK, [HUP USR1 USR2 PIPE ALRM CHLD TSTP URG VTALRM PROF WINCH IO], [], 8) = 0
[pid 71444] openat(AT_FDCWD</>, "/run/systemd/machines/localhost", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
[pid 71444] rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
[pid 71444] rt_sigprocmask(SIG_BLOCK, [HUP USR1 USR2 PIPE ALRM CHLD TSTP URG VTALRM PROF WINCH IO], [], 8) = 0
[pid 71444] socket(AF_UNIX, SOCK_STREAM|SOCK_CLOEXEC|SOCK_NONBLOCK, 0) = 3<UNIX-STREAM:[162498]>
[pid 71444] connect(3<UNIX-STREAM:[162498]>, {sa_family=AF_UNIX, sun_path="/run/systemd/resolve/io.systemd.Resolve"}, 42) = -1 ENOENT (No such file or directory)
[pid 71444] close(3<UNIX-STREAM:[162498]>) = 0
[pid 71444] rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
[pid 71444] openat(AT_FDCWD</>, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 3</etc/hosts>
[pid 71444] newfstatat(3</etc/hosts>, "", {st_mode=S_IFREG|0644, st_size=132, ...}, AT_EMPTY_PATH) = 0
[pid 71444] lseek(3</etc/hosts>, 0, SEEK_SET) = 0
[pid 71444] read(3</etc/hosts>, "# Static table lookup for hostnames.\n# See hosts(5) for details.\n127.0.0.1 localhost\n:;1 localhost\n127.0.1.1 null.as213279.net null\n", 4096) = 132
[pid 71444] read(3</etc/hosts>, "", 4096) = 0
[pid 71444] close(3</etc/hosts>)        = 0
[pid 71444] socket(AF_INET, SOCK_STREAM|SOCK_CLOEXEC, IPPROTO_TCP) = 3<TCP:[163057]>
[pid 71444] fcntl(3<TCP:[163057]>, F_GETFL) = 0x2 (flags O_RDWR)
[pid 71444] setsockopt(3<TCP:[163057]>, SOL_TCP, TCP_NODELAY, [1], 4) = 0
[pid 71444] fcntl(3<TCP:[163057]>, F_GETFL) = 0x2 (flags O_RDWR)
[pid 71444] connect(3<TCP:[163057]>, {sa_family=AF_INET, sin_port=htons(6379), sin_addr=inet_addr("127.0.0.1")}, 16) = 0
[pid 71444] fcntl(3<TCP:[127.0.0.1:55032->127.0.0.1:6379]>, F_GETFL) = 0x2 (flags O_RDWR)
[pid 71444] fcntl(3<TCP:[127.0.0.1:55032->127.0.0.1:6379]>, F_GETFL) = 0x2 (flags O_RDWR)
[pid 71444] fcntl(3<TCP:[127.0.0.1:55032->127.0.0.1:6379]>, F_SETFL, O_RDWR|O_NONBLOCK) = 0
[pid 71444] fcntl(3<TCP:[127.0.0.1:55032->127.0.0.1:6379]>, F_GETFL) = 0x802 (flags O_RDWR|O_NONBLOCK)
[pid 71444] fcntl(3<TCP:[127.0.0.1:55032->127.0.0.1:6379]>, F_SETFL, O_RDWR) = 0
[pid 71444] getpid()                    = 69755
[pid 71444] getpid()                    = 69755
[pid 71444] newfstatat(AT_FDCWD</>, "/var/log/irrd.log", {st_mode=S_IFREG|0644, st_size=1140909, ...}, 0) = 0
[pid 71444] write(3<TCP:[127.0.0.1:55032->127.0.0.1:6379]>, "2023-08-17 18:47:46,205 irrd[69755]: [irrd.storage.preload#DEBUG] Completed updating preload as-set store from thread <PreloadUpdater(Thread-2, started daemon 140457683707584)>\n", 177) = 177
```

Redis traffic:
```
T 127.0.0.1:34754 -> 127.0.0.1:6379 [AP] #449859
  2023-08-18 10:39:50,223 irrd[535945]: [irrd.storage.preload#DEBUG] Completed updating preload as-set
   store from thread <PreloadUpdater(Thread-1, started daemon 140192782476992)>.

T 127.0.0.1:6379 -> 127.0.0.1:34754 [AP] #449861
  -ERR unknown command '2023-08-18', with args beginning with: '10:39:50,223' 'irrd[535945]:' '[irrd.s
  torage.preload#DEBUG]' 'Completed' 'updating' 'preload' 'as-set' 'store' 'from' 'thread' ..

T 127.0.0.1:45436 -> 127.0.0.1:6379 [AP] #450118
  2023-08-18 10:40:14,753 irrd[535945]: [irrd.storage.preload#DEBUG] Completed updating preload route-
  set store from thread <PreloadUpdater(Thread-1, started daemon 140192782476992)>.

T 127.0.0.1:6379 -> 127.0.0.1:45436 [AP] #450119
  -ERR unknown command '2023-08-18', with args beginning with: '10:40:14,753' 'irrd[535945]:' '[irrd.s
  torage.preload#DEBUG]' 'Completed' 'updating' 'preload' 'route-set' 'store' 'from' 'thread' ..
```