### PR TITLE
Remove PyPy support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,25 +20,11 @@ workflows:
               python_version: ["3.8", "3.11"]
               postgres_version: ["15.0"]
               redis_version: ["5.0"]
-      - unit_tests_pypy:
-          name: unit-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9"]
-              postgres_version: ["15.0"]
-              redis_version: ["5.0"]
       - integration_tests_cpython:
           name: integration-tests-cpython<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
               python_version: ["3.8", "3.11"]
-              postgres_version: ["15.0"]
-              redis_version: ["5.0"]
-      - integration_tests_pypy:
-          name: integration-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9"]
               postgres_version: ["15.0"]
               redis_version: ["5.0"]
       - lint:
@@ -59,25 +45,11 @@ workflows:
               python_version: ["3.8", "3.9", "3.10", "3.11"]
               postgres_version: ["9.6", "11.16", "13.7", "15.0"]
               redis_version: ["5.0", "6.2", "7.0"]
-      - unit_tests_pypy:
-          name: unit-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9"]
-              postgres_version: ["9.6", "11.16", "13.7", "15.0"]
-              redis_version: ["5.0", "6.2", "7.0"]
       - integration_tests_cpython:
           name: integration-tests-cpython<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
           matrix:
             parameters:
               python_version: ["3.8", "3.9", "3.10", "3.11"]
-              postgres_version: ["9.6", "11.16", "13.7", "15.0"]
-              redis_version: ["5.0", "6.2", "7.0"]
-      - integration_tests_pypy:
-          name: integration-tests-pypy<< matrix.python_version >>-pg<< matrix.postgres_version >>-redis<< matrix.redis_version >>
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9"]
               postgres_version: ["9.6", "11.16", "13.7", "15.0"]
               redis_version: ["5.0", "6.2", "7.0"]
       - lint:
@@ -171,7 +143,6 @@ commands:
           path: /tmp/pytest-of-circleci/
 
 
-
 jobs:
   unit_tests_cpython:
     parameters:
@@ -191,43 +162,6 @@ jobs:
           IRRD_REDIS_URL: 'redis://localhost'
           PYTHON_INTERPRETER: python3
           SUDO: sudo
-
-      - image: cimg/postgres:<< parameters.postgres_version >>
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-        command: postgres -c track_commit_timestamp=true
-
-      - image: cimg/redis:<< parameters.redis_version >>
-#      - image: cimg/rust:1.65
-
-    steps:
-      - checkout
-      - install_dependencies
-      - wait_for_postgres
-      - run_unit_tests
-      - store_results
-
-
-  unit_tests_pypy:
-    parameters:
-      python_version:
-        type: string
-      postgres_version:
-        type: string
-      redis_version:
-        type: string
-
-    resource_class: medium
-    working_directory: /mnt/ramdisk
-    docker:
-      - image: pypy:<< parameters.python_version >>
-        environment:
-          IRRD_DATABASE_URL: 'postgresql://root@localhost/circle_test'
-          IRRD_REDIS_URL: 'redis://localhost'
-          PYTHON_INTERPRETER: pypy3
-          SUDO: ''
 
       - image: cimg/postgres:<< parameters.postgres_version >>
         environment:
@@ -267,46 +201,6 @@ jobs:
           IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
           PYTHON_INTERPRETER: python3
           SUDO: sudo
-
-      - image: cimg/postgres:<< parameters.postgres_version >>
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
-          POSTGRES_HOST_AUTH_METHOD: trust
-        command: postgres -c track_commit_timestamp=true
-
-      - image: cimg/redis:<< parameters.redis_version >>
-#      - image: cimg/rust:1.65
-
-    steps:
-      - checkout
-      - install_dependencies
-      - wait_for_postgres
-      - create_integration_test_db
-      - run_integration_tests
-      - store_results
-
-
-  integration_tests_pypy:
-    parameters:
-      python_version:
-        type: string
-      postgres_version:
-        type: string
-      redis_version:
-        type: string
-
-    resource_class: large
-    working_directory: /mnt/ramdisk
-    docker:
-      - image: pypy:<< parameters.python_version >>
-        environment:
-          IRRD_DATABASE_URL_INTEGRATION_1: 'postgresql://root@localhost/circle_test_integration_1'
-          IRRD_DATABASE_URL_INTEGRATION_2: 'postgresql://root@localhost/circle_test_integration_2'
-          IRRD_REDIS_URL_INTEGRATION_1: 'redis://localhost/4'
-          IRRD_REDIS_URL_INTEGRATION_2: 'redis://localhost/5'
-          PYTHON_INTERPRETER: pypy3
-          SUDO: ''
 
       - image: cimg/postgres:<< parameters.postgres_version >>
         environment:

--- a/docs/admins/deployment.rst
+++ b/docs/admins/deployment.rst
@@ -20,12 +20,8 @@ Requirements
 IRRd requires:
 
 * Linux, OpenBSD or MacOS. Other platforms are untested, but may work.
-* PyPy or CPython 3.8 through 3.11 with `pip` and `virtualenv` installed.
-  PyPy is slightly recommended over CPython (the "default" Python interpreter),
-  due to improved performance, in the order of 10% for some queries,
-  and even higher for some GraphQL queries. However, CPython remains fully
-  supported, and CPython may be the better option for you if it is easier to
-  install on your deployment platform.
+* CPython ("regular" Python) 3.8 through 3.11 with `pip` and `virtualenv`
+  installed. PyPy was previously supported, but not anymore.
 * A recent version of PostgreSQL. Versions 9.6, 11.16, 13.7, 15.0 are all
   tested before release. 11 or higher is strongly recommended, due to faster
   database migrations during upgrades.

--- a/docs/releases/4.4.0.rst
+++ b/docs/releases/4.4.0.rst
@@ -15,10 +15,15 @@ IRRD 4.4.0 was released on TODO. Highlights of new features:
   queries that include `as-set` and `route-set` resolving.
 
 
-Minimum Python version
-----------------------
+Minimum Python version and PyPy
+-------------------------------
 The minimum Python version for IRRd is now 3.8. Python 3.7 is `end of life`_
 as of 27 June 2023 and therefore no longer supported.
+
+IRRD no longer supports PyPy. While it offered some performance
+benefit, it kept causing numerous complex issues.
+If you were running on PyPy, switch your environment to CPython,
+the commonly used Python interpreter.
 
 .. _end of life: https://endoflife.date/python
 


### PR DESCRIPTION
PyPy support has been dropped due to repeated complex issues at a quite limited performance improvement. The PyPy specific issues are often highly complicated to debug, e.g. #578, #774, #848. Latest issue was infinite memory usage growth in the ROA importer, which I have not been able to debug successfully. The time spent on all these issues is not worth the slight performance boost.

This commit removes CI and updates the docs, but does not remove the few lines of PyPy compatibility code.
