### PR TITLE
Optimize route preference validator checks

### DIFF
--- a/irrd/routepref/routepref.py
+++ b/irrd/routepref/routepref.py
@@ -138,6 +138,14 @@ def update_route_preference_status(
     and an optional set of prefixes to limit the evaluation.
     Results are saved to the database and counters are logged.
     """
+    if not any(
+        [
+            source_setting.get("route_object_preference", None)
+            for source_setting in get_setting("sources", {}).values()
+        ]
+    ):
+        return
+
     if filter_prefixes and len(filter_prefixes) > MAX_FILTER_PREFIX_LEN:
         filter_prefixes = None
 

--- a/irrd/routepref/tests/test_routepref.py
+++ b/irrd/routepref/tests/test_routepref.py
@@ -17,6 +17,7 @@ def test_route_preference_validator(config_override):
                 "SRC-HIGH-B": {"route_object_preference": 900},
                 "SRC-LOWEST": {"route_object_preference": 100},
                 "SRC-LOW": {"route_object_preference": 200},
+                "SRC-NONE": {},
             }
         }
     )
@@ -218,3 +219,20 @@ def test_update_route_preference_status(config_override, monkeypatch):
             {"rpsl_objs_now_visible": [], "rpsl_objs_now_suppressed": []},
         )
     ]
+
+
+def test_update_route_preference_status_no_config(config_override, monkeypatch):
+    config_override(
+        {
+            "sources": {
+                "SRC-HIGH": {},
+                "SRC-LOW": {},
+            }
+        }
+    )
+
+    mock_dh = MockDatabaseHandler()
+    mock_dh.reset_mock()
+    update_route_preference_status(mock_dh)
+    assert mock_dh.queries == []
+    assert mock_dh.other_calls == []


### PR DESCRIPTION
* Don't run route preference for RPKI objects
* Don't run route preference if no sources have the setting
