### PR TITLE
Refuse to start under PyPy.

### DIFF
--- a/irrd/daemon/main.py
+++ b/irrd/daemon/main.py
@@ -5,6 +5,7 @@ import grp
 import logging
 import multiprocessing
 import os
+import platform
 import pwd
 import signal
 import sys
@@ -34,6 +35,10 @@ from irrd.utils.process_support import ExceptionLoggingProcess, set_traceback_ha
 
 
 def main():
+    if platform.python_implementation() == "PyPy":
+        print("IRRD can not be run under PyPy. Use CPython instead.")
+        sys.exit(1)
+
     description = """IRRd main process"""
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(

--- a/irrd/integration_tests/run.py
+++ b/irrd/integration_tests/run.py
@@ -40,7 +40,6 @@ from irrd.utils.rpsl_samples import (
 )
 from irrd.utils.whois_client import whois_query, whois_query_irrd
 
-from ..storage import translate_url
 from .constants import (
     EMAIL_DISCARD_MSGS_COMMAND,
     EMAIL_END,
@@ -941,7 +940,7 @@ class TestIntegration:
         alembic_cfg.set_main_option("script_location", f"{IRRD_ROOT_PATH}/irrd/storage/alembic")
         command.upgrade(alembic_cfg, "head")
 
-        connection = sa.create_engine(translate_url(self.database_url1)).connect()
+        connection = sa.create_engine(self.database_url1).connect()
         connection.execute("DELETE FROM rpsl_objects")
         connection.execute("DELETE FROM rpsl_database_journal")
         connection.execute("DELETE FROM database_status")
@@ -952,7 +951,7 @@ class TestIntegration:
         alembic_cfg.set_main_option("script_location", f"{IRRD_ROOT_PATH}/irrd/storage/alembic")
         command.upgrade(alembic_cfg, "head")
 
-        connection = sa.create_engine(translate_url(self.database_url2)).connect()
+        connection = sa.create_engine(self.database_url2).connect()
         connection.execute("DELETE FROM rpsl_objects")
         connection.execute("DELETE FROM rpsl_database_journal")
         connection.execute("DELETE FROM database_status")

--- a/irrd/storage/__init__.py
+++ b/irrd/storage/__init__.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import sqlalchemy as sa
 import ujson
@@ -14,7 +13,7 @@ def get_engine():
     if engine:
         return engine
     engine = sa.create_engine(
-        translate_url(get_setting("database_url")),
+        get_setting("database_url"),
         pool_size=50,
         json_deserializer=ujson.loads,
     )
@@ -35,11 +34,3 @@ def get_engine():
             )
 
     return engine
-
-
-def translate_url(url_str: str) -> sa.engine.url.URL:
-    """Translate a url string to a SQLAlchemy URL object with the right driver"""
-    url = sa.engine.url.make_url(url_str)
-    if url.drivername == "postgresql" and platform.python_implementation() == "PyPy":  # pragma: no cover
-        url.drivername = "postgresql+psycopg2cffi"
-    return url

--- a/irrd/storage/alembic/env.py
+++ b/irrd/storage/alembic/env.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from alembic import context
 from sqlalchemy import create_engine
 
-from irrd.storage import translate_url
-
 sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from irrd.conf import config_init, get_setting, is_config_initialised
@@ -30,7 +28,7 @@ def run_migrations_offline():
     """
     if not is_config_initialised():
         config_init(os.environ["IRRD_CONFIG_FILE"])
-    url = translate_url(get_setting("database_url"))
+    url = get_setting("database_url")
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -51,7 +49,7 @@ def run_migrations_online():
     """
     if not is_config_initialised():
         config_init(os.environ["IRRD_CONFIG_FILE"])
-    engine = create_engine(translate_url(get_setting("database_url")))
+    engine = create_engine(get_setting("database_url"))
 
     with engine.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1939,20 +1939,6 @@ files = [
 ]
 
 [[package]]
-name = "psycopg2cffi"
-version = "2.9.0"
-description = ".. image:: https://travis-ci.org/chtd/psycopg2cffi.svg?branch=master"
-optional = false
-python-versions = "*"
-files = [
-    {file = "psycopg2cffi-2.9.0.tar.gz", hash = "sha256:7e272edcd837de3a1d12b62185eb85c45a19feda9e62fa1b120c54f9e8d35c52"},
-]
-
-[package.dependencies]
-cffi = ">=1.0"
-six = "*"
-
-[[package]]
 name = "py-radix-sr"
 version = "1.0.0.post1"
 description = "Radix tree implementation"
@@ -3466,4 +3452,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ee665604b46ac0d906da6f7bcb5c69eefdd7559d4d960da617549205d3f4d9c4"
+content-hash = "6470d41663e11eaa1aa6e5d18cda62695560c4e264eaf687c311000d73f56ae5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ asgiref = "3.6.0"
 pydantic = "1.10.12"
 typing-extensions = "4.7.1"
 py-radix-sr = "1.0.0.post1"
-psycopg2-binary = { version = "2.9.7", markers = "platform_python_implementation == 'CPython'" }
-psycopg2cffi = { version = "2.9.0", markers = "platform_python_implementation == 'PyPy'" }
+psycopg2-binary = "2.9.7"
 sqlalchemy = "1.3.24"  # pinned <1.24
 alembic = "1.11.3"
 ujson = "5.8.0"
@@ -74,7 +73,7 @@ python-graphql-client = "^0.4.3"
 pytest-asyncio = "^0.20.3"
 freezegun = "^1.2.2"
 pytest-freezegun = "^0.4.2"
-mypy = { version = "^1.0.1", markers = "platform_python_implementation == 'CPython'" }
+mypy = "^1.0.1"
 ruff = "^0.0.252"
 isort = "^5.12.0"
 black = "23.7.0"


### PR DESCRIPTION
This is a follow-up from 6a7c9e839a53526d72d944381c755234e92007fc to prevent users from accidentally running under the no longer supported PyPy.
