### PR TITLE
Depend on poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,5 +167,5 @@ omit = [
 ]
 
 [build-system]
-requires = ["poetry"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
It is not necessary for all users to have the full poetry cli installed. [For example in the NixOS packaging](https://github.com/NixOS/nixpkgs/pull/271179#discussion_r1424005101)