### PR TITLE
Fix #892 - Enable refresh_on_error in NRTMv3 query response SQL queries

### DIFF
--- a/irrd/mirroring/nrtm_generator.py
+++ b/irrd/mirroring/nrtm_generator.py
@@ -34,7 +34,7 @@ class NRTMGenerator:
 
         q = DatabaseStatusQuery().source(source)
         try:
-            status = next(database_handler.execute_query(q))
+            status = next(database_handler.execute_query(q, refresh_on_error=True))
         except StopIteration:
             raise NRTMGeneratorException("There are no journal entries for this source.")
 
@@ -86,7 +86,7 @@ class NRTMGenerator:
             )
 
             try:
-                journal = next(database_handler.execute_query(q))
+                journal = next(database_handler.execute_query(q, refresh_on_error=True))
             except StopIteration:
                 raise NRTMGeneratorException(
                     "There are no journal entries greater than or equal to this serial"
@@ -114,7 +114,7 @@ class NRTMGenerator:
 
         output.append(f"%START Version: {version} {source} {serial_start_requested}-{serial_end_display}\n")
 
-        for operation in database_handler.execute_query(q):
+        for operation in database_handler.execute_query(q, refresh_on_error=True):
             operation_str = operation["operation"].value
             if version == "3":
                 operation_str += " " + str(operation["serial_nrtm"])

--- a/irrd/mirroring/tests/test_nrtm_generator.py
+++ b/irrd/mirroring/tests/test_nrtm_generator.py
@@ -48,7 +48,7 @@ def prepare_generator(monkeypatch, config_override):
             ],
         ]
     )
-    mock_dh.execute_query = lambda q: next(responses)
+    mock_dh.execute_query = lambda q, refresh_on_error: next(responses)
 
     yield NRTMGenerator(), mock_dh
 
@@ -151,7 +151,7 @@ class TestNRTMGenerator:
         generator, mock_dh = prepare_generator
 
         responses = repeat({"serial_oldest_journal": None, "serial_newest_journal": None})
-        mock_dh.execute_query = lambda q: responses
+        mock_dh.execute_query = lambda q, refresh_on_error: responses
 
         result = generator.generate("TEST", "3", 201, None, mock_dh)
         assert result == "% Warning: there are no updates available"
@@ -319,7 +319,7 @@ NRTM response header line2""",
             }
         )
 
-        mock_dh.execute_query = lambda q: iter(
+        mock_dh.execute_query = lambda q, refresh_on_error: iter(
             [
                 {
                     "serial_oldest_journal": 100,


### PR DESCRIPTION
As NRTM query responses are generated from whois servers with very
long running DB connections, they also need to accomodate for
disconnects and recover.
