### PR TITLE
Fix #647, fix #909 - Always parse delete object non-strict

### DIFF
--- a/irrd/updates/parser.py
+++ b/irrd/updates/parser.py
@@ -92,7 +92,7 @@ class ChangeRequest:
                 )
             except ValueError:
                 pass
-            if self.non_strict_mode:
+            if self.non_strict_mode or delete_reason:
                 self.rpsl_obj_new = rpsl_object_from_text(rpsl_text_submitted, strict_validation=False)
 
             if self.rpsl_obj_new.messages.errors():

--- a/irrd/updates/tests/test_handler.py
+++ b/irrd/updates/tests/test_handler.py
@@ -1071,7 +1071,6 @@ class TestChangeSubmissionHandler:
                             {"name": "person", "value": "Placeholder Person Object"},
                             {"name": "nic-hdl", "value": "PERSON-TEST"},
                             {"name": "changed", "value": "changed@example.com 20190701 # comment"},
-                            {"name": "source", "value": "TEST"},
                         ]
                     },
                 ],
@@ -1110,12 +1109,8 @@ class TestChangeSubmissionHandler:
         person: Placeholder Person Object
         nic-hdl: PERSON-TEST
         changed: changed@example.com 20190701 # comment
-        source: TEST
         
-        ERROR: Mandatory attribute "address" on object person is missing
-        ERROR: Mandatory attribute "phone" on object person is missing
-        ERROR: Mandatory attribute "e-mail" on object person is missing
-        ERROR: Mandatory attribute "mnt-by" on object person is missing
+        ERROR: Primary key attribute "source" on object person is missing
         ERROR: Can not delete object: no object found for this key in this database.
  
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When an object is deleted, the submitted object's values are
ignored except for the primary key. Therefore, there's no
need to validate them in strict mode.
This also disables the rules validator for deletion objects, re #909
