### PR TITLE
Add config for skipping setting last modified for authoritative object

### DIFF
--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -775,6 +775,11 @@ Sources
   discouraged**, as it allows reduced data integrity.
   |br| **Default**: ``false``, authoritative changes validated strictly.
   |br| **Change takes effect**: after SIGHUP, for all subsequent changes.
+* ``sources.{name}.authoritative_unset_last_modified``: a boolean for whether
+  to skip setting last-modified attribute when the authoritative object is
+  created or updated.
+  |br| **Default**: ``false``.
+  |br| **Change takes effect**: after SIGHUP, for all subsequent changes.
 
 
 For more detail on mirroring other sources, and providing mirroring services

--- a/docs/admins/configuration.rst
+++ b/docs/admins/configuration.rst
@@ -775,10 +775,11 @@ Sources
   discouraged**, as it allows reduced data integrity.
   |br| **Default**: ``false``, authoritative changes validated strictly.
   |br| **Change takes effect**: after SIGHUP, for all subsequent changes.
-* ``sources.{name}.authoritative_unset_last_modified``: a boolean for whether
-  to skip setting last-modified attribute when the authoritative object is
-  created or updated.
-  |br| **Default**: ``false``.
+* ``sources.{name}.authoritative_retain_last_modified``: whether to update
+  :ref:`last-modified <last-modified>` on authoritative objects when saving,
+  or to retain their original value, if any.
+  |br| **Default**: ``false``, last-modified is set/replaced when saving
+  authoritative objects.
   |br| **Change takes effect**: after SIGHUP, for all subsequent changes.
 
 

--- a/docs/admins/object-validation.rst
+++ b/docs/admins/object-validation.rst
@@ -116,13 +116,14 @@ last-modified
 For authoritative objects, the ``last-modified`` attribute is set when
 the object is created or updated. Any existing ``last-modified`` values are
 discarded. This timestamp is not updated for changes in object suppression
-status. This attribute is visible over NRTM and in exports.
+status. This attribute is visible over NRTM and in exports. The behaviour
+can be disabled with the ``sources.{name}.authoritative_retain_last_modified``
+setting.
 
 By default, this attribute is only added when an object is changed or
 created. If you have upgraded to IRRd 4.1, you can use the
 ``irrd_set_last_modified_auth`` command to set it to the current time on
 all existing authoritative objects.
-
 This may take in the order of 10 minutes, depending
 on the number of objects to be updated. This only needs to be done once.
 It is safe to execute while other IRRd processes are running.

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -108,4 +108,5 @@ KNOWN_SOURCES_KEYS = {
     "scopefilter_excluded",
     "suspension_enabled",
     "route_object_preference",
+    "authoritative_unset_last_modified",
 }

--- a/irrd/conf/known_keys.py
+++ b/irrd/conf/known_keys.py
@@ -108,5 +108,5 @@ KNOWN_SOURCES_KEYS = {
     "scopefilter_excluded",
     "suspension_enabled",
     "route_object_preference",
-    "authoritative_unset_last_modified",
+    "authoritative_retain_last_modified",
 }

--- a/irrd/rpsl/parser.py
+++ b/irrd/rpsl/parser.py
@@ -186,13 +186,20 @@ class RPSLObject(metaclass=RPSLObjectMeta):
         Render the RPSL object as an RPSL string.
         If last_modified is provided, removes existing last-modified:
         attributes and adds a new one with that timestamp, if self.source()
-        is authoritative and authoritative_unset_last_modified config is unset.
+        is authoritative and authoritative_retain_last_modified config is unset.
         """
         output = ""
         authoritative = get_setting(f"sources.{self.source()}.authoritative")
-        unset_last_modified = get_setting(f"sources.{self.source()}.authoritative_unset_last_modified", False)
+        authoritative_retain_last_modified = get_setting(
+            f"sources.{self.source()}.authoritative_retain_last_modified"
+        )
         for attr, value, continuation_chars in self._object_data:
-            if authoritative and last_modified and attr == "last-modified" and not unset_last_modified:
+            if (
+                authoritative
+                and last_modified
+                and attr == "last-modified"
+                and not authoritative_retain_last_modified
+            ):
                 continue
             attr_display = f"{attr}:".ljust(RPSL_ATTRIBUTE_TEXT_WIDTH)
             value_lines = list(splitline_unicodesafe(value))
@@ -208,7 +215,7 @@ class RPSLObject(metaclass=RPSLObjectMeta):
                         continuation_char = "+"
                     output += continuation_char + (RPSL_ATTRIBUTE_TEXT_WIDTH - 1) * " " + line
                 output += "\n"
-        if authoritative and last_modified and not unset_last_modified:
+        if authoritative and last_modified and not authoritative_retain_last_modified:
             output += "last-modified:".ljust(RPSL_ATTRIBUTE_TEXT_WIDTH)
             output += last_modified.replace(microsecond=0).isoformat().replace("+00:00", "Z")
             output += "\n"

--- a/irrd/rpsl/parser.py
+++ b/irrd/rpsl/parser.py
@@ -186,12 +186,13 @@ class RPSLObject(metaclass=RPSLObjectMeta):
         Render the RPSL object as an RPSL string.
         If last_modified is provided, removes existing last-modified:
         attributes and adds a new one with that timestamp, if self.source()
-        is authoritative.
+        is authoritative and authoritative_unset_last_modified config is unset.
         """
         output = ""
         authoritative = get_setting(f"sources.{self.source()}.authoritative")
+        unset_last_modified = get_setting(f"sources.{self.source()}.authoritative_unset_last_modified", False)
         for attr, value, continuation_chars in self._object_data:
-            if authoritative and last_modified and attr == "last-modified":
+            if authoritative and last_modified and attr == "last-modified" and not unset_last_modified:
                 continue
             attr_display = f"{attr}:".ljust(RPSL_ATTRIBUTE_TEXT_WIDTH)
             value_lines = list(splitline_unicodesafe(value))
@@ -207,7 +208,7 @@ class RPSLObject(metaclass=RPSLObjectMeta):
                         continuation_char = "+"
                     output += continuation_char + (RPSL_ATTRIBUTE_TEXT_WIDTH - 1) * " " + line
                 output += "\n"
-        if authoritative and last_modified:
+        if authoritative and last_modified and not unset_last_modified:
             output += "last-modified:".ljust(RPSL_ATTRIBUTE_TEXT_WIDTH)
             output += last_modified.replace(microsecond=0).isoformat().replace("+00:00", "Z")
             output += "\n"

--- a/irrd/rpsl/tests/test_rpsl_objects.py
+++ b/irrd/rpsl/tests/test_rpsl_objects.py
@@ -629,9 +629,9 @@ class TestLastModified:
         expected_text = rpsl_text + "last-modified:  old-value\n"
         assert obj.render_rpsl_text(last_modified=last_modified) == expected_text
 
-    def test_unset_last_modified(self, config_override):
+    def test_authoritative_retain_last_modified(self, config_override):
         config_override(
-            {"sources": {"TEST": {"authoritative": True, "authoritative_unset_last_modified": True}}}
+            {"sources": {"TEST": {"authoritative": True, "authoritative_retain_last_modified": True}}}
         )
         rpsl_text = object_sample_mapping[RPSLRtrSet().rpsl_object_class]
         obj = rpsl_object_from_text(rpsl_text + "last-modified: old-value\n")

--- a/irrd/rpsl/tests/test_rpsl_objects.py
+++ b/irrd/rpsl/tests/test_rpsl_objects.py
@@ -628,3 +628,14 @@ class TestLastModified:
         last_modified = datetime.datetime(2020, 1, 1, tzinfo=timezone("UTC"))
         expected_text = rpsl_text + "last-modified:  old-value\n"
         assert obj.render_rpsl_text(last_modified=last_modified) == expected_text
+
+    def test_unset_last_modified(self, config_override):
+        config_override(
+            {"sources": {"TEST": {"authoritative": True, "authoritative_unset_last_modified": True}}}
+        )
+        rpsl_text = object_sample_mapping[RPSLRtrSet().rpsl_object_class]
+        obj = rpsl_object_from_text(rpsl_text + "last-modified: old-value\n")
+        assert not obj.messages.errors()
+        last_modified = datetime.datetime(2020, 1, 1, tzinfo=timezone("UTC"))
+        expected_text = rpsl_text + "last-modified:  old-value\n"
+        assert obj.render_rpsl_text(last_modified=last_modified) == expected_text


### PR DESCRIPTION
For the authoritative source, add a config for skipping setting the last-modified attribute in the object so that the original value can be preserved. Also, the object won't have two attributes(changed and last-modified) having two different dates.
