### PR TITLE
Make readonly_standby/export_destination conflict explicit

### DIFF
--- a/docs/admins/availability-and-migration.rst
+++ b/docs/admins/availability-and-migration.rst
@@ -76,7 +76,7 @@ There are several important requirements for this setup:
 * The PostgreSQL configuration must have ``track_commit_timestamp``
   and ``hot_standby_feedback`` enabled.
 * On the standby, you run the IRRD instance with the ``readonly_standby``
-  parameters set.
+  setting on.
 * The standby instance must use its own Redis instance. Do not use
   Redis replication.
 * ``rpki.roa_source`` must be consistent between active and standby
@@ -86,7 +86,8 @@ There are several important requirements for this setup:
   ``sources.{name}.object_class_filter`` consistent between active
   and standby. Note that you can not set
   ``sources.{name}.authoritative``, ``sources.{name}.nrtm_host``,
-  ``sources.{name}.import_source``, ``sources.{name}.nrtm4_client_notification_file_url``, or
+  ``sources.{name}.import_source``, ``sources.{name}.import_source``,
+  ``sources.{name}.export_destination``, ``sources.{name}.export_destination_unfiltered``, or
   ``sources.{name}.nrtm4_client_initial_public_key`` on a standby instance, as these
   conflict with ``readonly_standby``.
 * All instances must run the same IRRD version.

--- a/irrd/conf/__init__.py
+++ b/irrd/conf/__init__.py
@@ -441,6 +441,8 @@ class Configuration:
                 details.get("authoritative")
                 or details.get("nrtm_host")
                 or details.get("import_source")
+                or details.get("export_destination")
+                or details.get("export_destination_unfiltered")
                 or nrtm4_client_unf_url
             ):
                 errors.append(


### PR DESCRIPTION
The config would allow both of these to be set, even though the
exporter would never run. It can't, because it stores the last
export time.
