### PR TITLE
Docs: Update Redis maxmem recommendation

### DIFF
--- a/docs/admins/deployment.rst
+++ b/docs/admins/deployment.rst
@@ -104,7 +104,7 @@ Redis is required for communication and persistence between IRRd's processes.
 IRRd releases are tested on Redis 5, 6 and 7.
 Beyond a default Redis installation, it is recommended to:
 
-* Increase ``maxmemory`` to 1GB (no limit is also fine). This is a hard
+* Increase ``maxmemory`` to 2GB (no limit is also fine). This is a hard
   requirement - IRRd will exceed the default maximum memory otherwise.
 * Disable snapshotting, by removing all ``save`` lines from the
   Redis configuration. IRRd always reloads the existing data upon startup


### PR DESCRIPTION
We ran into the 1 Gb Redis memory limit when importing RPSL from the RIPE repository. This PR suggests increasing the recommended value to 2 Gb.