### PR TITLE
Add rpsl_data_updated to database status, seperate from existing updated

### DIFF
--- a/docs/admins/prometheus-metrics.rst
+++ b/docs/admins/prometheus-metrics.rst
@@ -66,21 +66,49 @@ Source updates and errors
 The next part exposes information on when the source was last updated and
 when the last error occurred.
 
-* `irrd_last_update_seconds`: seconds since the last update
+The ``irrd_last_update_*`` and ``irrd_last_rpsl_data_update_*`` fields
+sounds similar, but have significant differences: the former updates when
+anything is changed in the internal state of the source. That includes RPSL
+data changes, but also recording an error, making an export, etc.
+The ``irrd_last_rpsl_data_update_*`` fields only update after a modification
+to the RPSL data. This includes changes in visibility due to object
+suppression status.
+
+* `irrd_last_update_seconds`: seconds since the last update to RPSL data
 
     .. code-block::
 
-        # HELP irrd_last_update_seconds Seconds since the last update
+        # HELP irrd_last_rpsl_data_update_seconds Seconds since the last update to RPSL data
+        # TYPE irrd_last_rpsl_data_update_seconds gauge
+        irrd_last_rpsl_data_update_seconds{source="SOURCE1"} 2289
+        irrd_last_rpsl_data_update_seconds{source="SOURCE2"} 4301
+        irrd_last_rpsl_data_update_seconds{source="RPKI"} 10
+
+* `irrd_last_update_timestamp`: UNIX timestamp of the last update to RPSL data
+
+    .. code-block::
+
+        # HELP irrd_last_rpsl_data_update_timestamp Timestamp of the last update to RPSL data in seconds since UNIX epoch
+        # TYPE irrd_last_rpsl_data_update_timestamp gauge
+        irrd_last_rpsl_data_update_timestamp{source="SOURCE1"} 1699965265
+        irrd_last_rpsl_data_update_timestamp{source="SOURCE2"} 1699963253
+        irrd_last_rpsl_data_update_timestamp{source="RPKI"} 1699967543
+
+* `irrd_last_update_seconds`: seconds since the last internal status change
+
+    .. code-block::
+
+        # HELP irrd_last_update_seconds Seconds since the last internal status change
         # TYPE irrd_last_update_seconds gauge
         irrd_last_update_seconds{source="SOURCE1"} 2289
         irrd_last_update_seconds{source="SOURCE2"} 4301
         irrd_last_update_seconds{source="RPKI"} 10
 
-* `irrd_last_update_timestamp`: UNIX timestamp of the last update
+* `irrd_last_update_timestamp`: UNIX timestamp of the last internal status change
 
     .. code-block::
 
-        # HELP irrd_last_update_timestamp Timestamp of the last update in seconds since UNIX epoch
+        # HELP irrd_last_update_timestamp Timestamp of the last internal status change in seconds since UNIX epoch
         # TYPE irrd_last_update_timestamp gauge
         irrd_last_update_timestamp{source="SOURCE1"} 1699965265
         irrd_last_update_timestamp{source="SOURCE2"} 1699963253

--- a/docs/admins/status_page.rst
+++ b/docs/admins/status_page.rst
@@ -45,8 +45,12 @@ The local information shows:
   or is missing due to temporary disabling of journal keeping.
 * `Last export at serial number`: serial at which this IRRd instance last
   created an export for this source, if any.
-* `Last update`: the last time when a change was processed for this source,
-  either by user submitted changes, NRTMv3 operations, or a full import.
+* `Last change to RPSL data`: the last time when the RPSL data for this source
+  changed, due to adding, updating or removing an RPSL object.
+  This includes changes in visibility due to object suppression status.
+* `Last internal status update`: the last time when the internal state of this
+  source was changed, either by an NRTM import or export, full import or export,
+  recording an error, RPKI status change, or user submitted changes.
 * `Local journal kept`: whether local journal keeping is enabled.
 * `Last import error occurred at`: when the most recent import error occurred,
   for mirrored sources. An import error means an object

--- a/docs/releases/4.5.0.rst
+++ b/docs/releases/4.5.0.rst
@@ -37,6 +37,19 @@ was added to the HTTP server in IRRD, on ``/metrics/``.
 This page is only accessible to IPs :doc:`configured </admins/configuration>`
 in the access list set in the ``server.http.status_access_list`` setting.
 
+New "RPSL data updated" status timestamp
+----------------------------------------
+Various status overviews of IRRD would show a "last update" per source.
+While there are uses for this, many users checked this to ensure mirroring
+from a remote source was still active. However, that is not what this
+indicates. This timestamp updates for any internal change to database
+status, including any exports.
+
+To cover the common use, a new timestamp was added for the last time
+the RPSL data for a source changed. This updates when objects are added,
+modified or deleted through any method, including a change in visibility
+due to object suppression status.
+
 Other changes
 -------------
 * The ``sources.{name}.object_class_filter`` setting can now also be used

--- a/docs/users/queries/graphql.rst
+++ b/docs/users/queries/graphql.rst
@@ -276,9 +276,12 @@ are an alias. Other sources have the the following fields for each valid source:
   This number can be compared to the serials reported by the mirror
   directly, to see whether IRRd is up to date. This number is independent
   from the range in the local journal.
-* ``lastUpdate``: the time of the last change to this source. This may be
-  an authoritative change, an update from a mirror, a re-import, a change
-  in the RPKI status of an object, or something else.
+* ``rpslDataUpdated``: the last time when the RPSL data for this source
+  changed, due to adding, updating or removing an RPSL object.
+  This includes changes in visibility due to object suppression status.
+* ``lastUpdate``: the last time when the internal state of this
+  source was changed, either by an NRTM import or export, full import or export,
+  recording an error, RPKI status change, or user submitted changes.
 * ``synchronisedSerials``: whether or not a mirrored source is running with
   :ref:`synchronised serials <mirroring-nrtm-serials>`.
 

--- a/irrd/mirroring/nrtm4/nrtm4_client.py
+++ b/irrd/mirroring/nrtm4/nrtm4_client.py
@@ -94,15 +94,17 @@ class NRTM4Client:
                 f" {self.last_status.current_key} to {used_key}"
             )
 
-        self.database_handler.record_nrtm4_client_status(
-            self.source,
-            NRTM4ClientDatabaseStatus(
-                session_id=unf.session_id,
-                version=unf.version,
-                current_key=used_key,
-                next_key=unf.next_signing_key,
-            ),
+        new_status = NRTM4ClientDatabaseStatus(
+            session_id=unf.session_id,
+            version=unf.version,
+            current_key=used_key,
+            next_key=unf.next_signing_key,
         )
+        if self.last_status != new_status:
+            self.database_handler.record_nrtm4_client_status(
+                self.source,
+                new_status,
+            )
         return has_loaded_snapshot
 
     def _retrieve_unf(self) -> Tuple[NRTM4UpdateNotificationFile, Optional[str]]:

--- a/irrd/server/graphql/schema_generator.py
+++ b/irrd/server/graphql/schema_generator.py
@@ -83,6 +83,7 @@ class SchemaGenerator:
                 nrtm4ServerVersion: Int
                 nrtm4ServerLastUpdateNotificationFileUpdate: String
                 nrtm4ServerLastSnapshotVersion: Int
+                rpslDataUpdated: String
                 lastUpdate: String
                 synchronisedSerials: Boolean!
                 aliased_sources: [String!]

--- a/irrd/server/graphql/tests/test_schema_generator.py
+++ b/irrd/server/graphql/tests/test_schema_generator.py
@@ -59,6 +59,7 @@ enum RoutePreferenceStatus {
                 nrtm4ServerVersion: Int
                 nrtm4ServerLastUpdateNotificationFileUpdate: String
                 nrtm4ServerLastSnapshotVersion: Int
+                rpslDataUpdated: String
                 lastUpdate: String
                 synchronisedSerials: Boolean!
                 aliased_sources: [String!]

--- a/irrd/server/http/status_generator.py
+++ b/irrd/server/http/status_generator.py
@@ -142,7 +142,8 @@ class StatusGenerator:
                 NRTMv4 server: last snapshot version: {status_result['nrtm4_server_last_snapshot_version']}
                 NRTMv4 server: number of deltas: {len(status_result['nrtm4_server_previous_deltas'] or [])}
                 Synchronised NRTM serials: {synchronised_serials_str}
-                Last update: {status_result['updated']}
+                Last change to RPSL data: {status_result['rpsl_data_updated']}
+                Last internal status update: {status_result['updated']}
                 Local journal kept: {keep_journal}
                 Last import error occurred at: {status_result['last_error_timestamp']}
                 RPKI validation enabled: {rpki_enabled_str}

--- a/irrd/server/http/tests/test_metrics_generator.py
+++ b/irrd/server/http/tests/test_metrics_generator.py
@@ -49,6 +49,7 @@ class TestMetricsGenerator:
                         "nrtm4_client_session_id": None,
                         "nrtm4_client_version": None,
                         "last_error_timestamp": datetime.fromtimestamp(10, UTC),
+                        "rpsl_data_updated": datetime.fromtimestamp(17, UTC),
                         "updated": datetime.fromtimestamp(18, UTC),
                     },
                     {
@@ -62,6 +63,7 @@ class TestMetricsGenerator:
                         "nrtm4_client_session_id": nrtm4_client_session_id,
                         "nrtm4_client_version": 14,
                         "last_error_timestamp": None,
+                        "rpsl_data_updated": datetime.fromtimestamp(14, UTC),
                         "updated": datetime.fromtimestamp(15, UTC),
                     },
                 ],
@@ -93,12 +95,22 @@ class TestMetricsGenerator:
             irrd_object_class_total{source="TEST1", object_class="route"} 10
             irrd_object_class_total{source="TEST2", object_class="route"} 42
             
-            # HELP irrd_last_update_seconds Seconds since the last update
+            # HELP irrd_last_rpsl_data_update_seconds Seconds since the last update to RPSL data
+            # TYPE irrd_last_rpsl_data_update_seconds gauge
+            irrd_last_rpsl_data_update_seconds{source="TEST1"} 33
+            irrd_last_rpsl_data_update_seconds{source="TEST2"} 36
+            
+            # HELP irrd_last_rpsl_data_update_timestamp Timestamp of the last update to RPSL data in seconds since UNIX epoch
+            # TYPE irrd_last_rpsl_data_update_timestamp gauge
+            irrd_last_rpsl_data_update_timestamp{source="TEST1"} 17
+            irrd_last_rpsl_data_update_timestamp{source="TEST2"} 14
+            
+            # HELP irrd_last_update_seconds Seconds since the last internal status change
             # TYPE irrd_last_update_seconds gauge
             irrd_last_update_seconds{source="TEST1"} 32
             irrd_last_update_seconds{source="TEST2"} 35
             
-            # HELP irrd_last_update_timestamp Timestamp of the last update in seconds since UNIX epoch
+            # HELP irrd_last_update_timestamp Timestamp of the last internal status change in seconds since UNIX epoch
             # TYPE irrd_last_update_timestamp gauge
             irrd_last_update_timestamp{source="TEST1"} 18
             irrd_last_update_timestamp{source="TEST2"} 15

--- a/irrd/server/http/tests/test_status_generator.py
+++ b/irrd/server/http/tests/test_status_generator.py
@@ -106,6 +106,7 @@ class TestStatusGenerator:
                         "nrtm4_server_last_snapshot_version": 21,
                         "nrtm4_server_previous_deltas": ["d1", "d2"],
                         "last_error_timestamp": datetime(2018, 1, 1, tzinfo=timezone.utc),
+                        "rpsl_data_updated": datetime(2017, 6, 1, tzinfo=timezone.utc),
                         "updated": datetime(2018, 6, 1, tzinfo=timezone.utc),
                     },
                     {
@@ -124,6 +125,7 @@ class TestStatusGenerator:
                         "nrtm4_server_last_snapshot_version": None,
                         "nrtm4_server_previous_deltas": None,
                         "last_error_timestamp": datetime(2019, 1, 1, tzinfo=timezone.utc),
+                        "rpsl_data_updated": datetime(2018, 6, 1, tzinfo=timezone.utc),
                         "updated": datetime(2019, 6, 1, tzinfo=timezone.utc),
                     },
                     {
@@ -142,6 +144,7 @@ class TestStatusGenerator:
                         "nrtm4_server_last_snapshot_version": None,
                         "nrtm4_server_previous_deltas": None,
                         "last_error_timestamp": None,
+                        "rpsl_data_updated": None,
                         "updated": None,
                     },
                     {
@@ -160,6 +163,7 @@ class TestStatusGenerator:
                         "nrtm4_server_last_snapshot_version": None,
                         "nrtm4_server_previous_deltas": None,
                         "last_error_timestamp": None,
+                        "rpsl_data_updated": None,
                         "updated": None,
                     },
                     {
@@ -178,6 +182,7 @@ class TestStatusGenerator:
                         "nrtm4_server_last_snapshot_version": None,
                         "nrtm4_server_previous_deltas": None,
                         "last_error_timestamp": None,
+                        "rpsl_data_updated": None,
                         "updated": None,
                     },
                 ],
@@ -221,7 +226,8 @@ class TestStatusGenerator:
                 NRTMv4 server: last snapshot version: 21
                 NRTMv4 server: number of deltas: 2
                 Synchronised NRTM serials: No
-                Last update: 2018-06-01 00:00:00+00:00
+                Last change to RPSL data: 2017-06-01 00:00:00+00:00
+                Last internal status update: 2018-06-01 00:00:00+00:00
                 Local journal kept: Yes
                 Last import error occurred at: 2018-01-01 00:00:00+00:00
                 RPKI validation enabled: No
@@ -255,7 +261,8 @@ class TestStatusGenerator:
                 NRTMv4 server: last snapshot version: None
                 NRTMv4 server: number of deltas: 0
                 Synchronised NRTM serials: No
-                Last update: 2019-06-01 00:00:00+00:00
+                Last change to RPSL data: 2018-06-01 00:00:00+00:00
+                Last internal status update: 2019-06-01 00:00:00+00:00
                 Local journal kept: No
                 Last import error occurred at: 2019-01-01 00:00:00+00:00
                 RPKI validation enabled: Yes
@@ -286,7 +293,8 @@ class TestStatusGenerator:
                 NRTMv4 server: last snapshot version: None
                 NRTMv4 server: number of deltas: 0
                 Synchronised NRTM serials: No
-                Last update: None
+                Last change to RPSL data: None
+                Last internal status update: None
                 Local journal kept: No
                 Last import error occurred at: None
                 RPKI validation enabled: Yes
@@ -317,7 +325,8 @@ class TestStatusGenerator:
                 NRTMv4 server: last snapshot version: None
                 NRTMv4 server: number of deltas: 0
                 Synchronised NRTM serials: No
-                Last update: None
+                Last change to RPSL data: None
+                Last internal status update: None
                 Local journal kept: No
                 Last import error occurred at: None
                 RPKI validation enabled: Yes
@@ -347,7 +356,8 @@ class TestStatusGenerator:
                 NRTMv4 server: last snapshot version: None
                 NRTMv4 server: number of deltas: 0
                 Synchronised NRTM serials: No
-                Last update: None
+                Last change to RPSL data: None
+                Last internal status update: None
                 Local journal kept: No
                 Last import error occurred at: None
                 RPKI validation enabled: Yes

--- a/irrd/server/query_resolver.py
+++ b/irrd/server/query_resolver.py
@@ -405,6 +405,9 @@ class QueryResolver:
             results[source]["nrtm4_server_last_snapshot_version"] = query_result[
                 "nrtm4_server_last_snapshot_version"
             ]
+            results[source]["rpsl_data_updated"] = (
+                query_result["rpsl_data_updated"].astimezone(timezone("UTC")).isoformat()
+            )
             results[source]["last_update"] = query_result["updated"].astimezone(timezone("UTC")).isoformat()
             results[source]["synchronised_serials"] = is_serial_synchronised(self.database_handler, source)
 

--- a/irrd/server/tests/test_query_resolver.py
+++ b/irrd/server/tests/test_query_resolver.py
@@ -589,6 +589,7 @@ class TestQueryResolver:
                     2020, 1, 1, tzinfo=datetime.timezone.utc
                 ),
                 "nrtm4_server_last_snapshot_version": 21,
+                "rpsl_data_updated": datetime.datetime(2019, 1, 1, tzinfo=timezone("UTC")),
                 "updated": datetime.datetime(2020, 1, 1, tzinfo=timezone("UTC")),
             },
             {
@@ -603,6 +604,7 @@ class TestQueryResolver:
                 "nrtm4_server_version": None,
                 "nrtm4_server_last_update_notification_file_update": None,
                 "nrtm4_server_last_snapshot_version": None,
+                "rpsl_data_updated": datetime.datetime(2019, 1, 1, tzinfo=timezone("UTC")),
                 "updated": datetime.datetime(2020, 1, 1, tzinfo=timezone("UTC")),
             },
         ]
@@ -630,6 +632,7 @@ class TestQueryResolver:
                     ("nrtm4_server_version", 22),
                     ("nrtm4_server_last_update_notification_file_update", "2020-01-01T00:00:00+00:00"),
                     ("nrtm4_server_last_snapshot_version", 21),
+                    ("rpsl_data_updated", "2019-01-01T00:00:00+00:00"),
                     ("last_update", "2020-01-01T00:00:00+00:00"),
                     ("synchronised_serials", False),
                 ]
@@ -659,6 +662,7 @@ class TestQueryResolver:
                             ("nrtm4_server_version", None),
                             ("nrtm4_server_last_update_notification_file_update", None),
                             ("nrtm4_server_last_snapshot_version", None),
+                            ("rpsl_data_updated", "2019-01-01T00:00:00+00:00"),
                             ("last_update", "2020-01-01T00:00:00+00:00"),
                             ("synchronised_serials", False),
                         ]

--- a/irrd/storage/alembic/versions/a635d2217a48_add_rpsl_data_updated_field_to_database_.py
+++ b/irrd/storage/alembic/versions/a635d2217a48_add_rpsl_data_updated_field_to_database_.py
@@ -1,0 +1,28 @@
+"""Add rpsl_data_updated field to database_status
+
+Revision ID: a635d2217a48
+Revises: b7b3c367f9ba
+Create Date: 2024-11-08 16:11:21.101990
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a635d2217a48"
+down_revision = "b7b3c367f9ba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "database_status",
+        sa.Column(
+            "rpsl_data_updated", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("database_status", "rpsl_data_updated")

--- a/irrd/storage/models.py
+++ b/irrd/storage/models.py
@@ -302,6 +302,8 @@ class RPSLDatabaseStatus(Base):  # type: ignore
     last_error = sa.Column(sa.Text)
     last_error_timestamp = sa.Column(sa.DateTime(timezone=True))
 
+    rpsl_data_updated = sa.Column(sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False)
+
     created = sa.Column(sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False)
     updated = sa.Column(
         sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False

--- a/irrd/storage/queries.py
+++ b/irrd/storage/queries.py
@@ -575,6 +575,7 @@ class DatabaseStatusQuery(BaseDatabaseQuery):
                 self.columns.synchronised_serials,
                 self.columns.last_error,
                 self.columns.last_error_timestamp,
+                self.columns.rpsl_data_updated,
                 self.columns.created,
                 self.columns.updated,
             ]

--- a/irrd/storage/tests/test_database.py
+++ b/irrd/storage/tests/test_database.py
@@ -1021,7 +1021,14 @@ class TestDatabaseHandlerLive:
         assert len(list(dh.execute_query(RPSLDatabaseJournalQuery()))) == 2  # no new entry since last test
 
     def _clean_result(self, results):
-        variable_fields = ["pk", "timestamp", "created", "updated", "last_error_timestamp"]
+        variable_fields = [
+            "pk",
+            "timestamp",
+            "created",
+            "updated",
+            "last_error_timestamp",
+            "rpsl_data_updated",
+        ]
         return [{k: v for k, v in result.items() if k not in variable_fields} for result in list(results)]
 
     def test_suspension(


### PR DESCRIPTION
The updated field was updated for any internal state change, which
causes it to update even when an export is made.

The new rpsl_data_updated field updates only when RPSL objects are
inserted, removed or updated for the source.
