### PR TITLE
Fix #949 - Add support for inline PGP signatures in RPSL update form

### DIFF
--- a/docs/releases/4.5.0.rst
+++ b/docs/releases/4.5.0.rst
@@ -57,6 +57,8 @@ as of 7 October 2024 and therefore no longer supported.
 
 Other changes
 -------------
+* The RPSL update submission page, on `/rpsl/update/`, now also accepts
+  inline PGP signed messages for mntner authentication.
 * The ``sources.{name}.object_class_filter`` setting can now also be used
   to restrict permitted changes to authoritative objects.
 * The setting ``sources.{name}.authoritative_retain_last_modified`` was

--- a/irrd/utils/pgp.py
+++ b/irrd/utils/pgp.py
@@ -79,5 +79,5 @@ def validate_pgp_signature(
     logger.info(f"checked PGP signature, response: {log_message}")
     if result.valid and result.key_status is None:
         logger.info(f"Found valid PGP signature, fingerprint {result.fingerprint}")
-        return new_message, result.fingerprint
+        return new_message, result.pubkey_fingerprint
     return None, None

--- a/irrd/utils/pgp.py
+++ b/irrd/utils/pgp.py
@@ -78,6 +78,6 @@ def validate_pgp_signature(
     log_message = result.stderr.replace("\n", " -- ").replace("gpg:                ", "")
     logger.info(f"checked PGP signature, response: {log_message}")
     if result.valid and result.key_status is None:
-        logger.info(f"Found valid PGP signature, fingerprint {result.fingerprint}")
+        logger.info(f"Found valid PGP signature, pubkey fingerprint {result.pubkey_fingerprint}, fingerprint {result.fingerprint}")
         return new_message, result.pubkey_fingerprint
     return None, None

--- a/irrd/utils/pgp.py
+++ b/irrd/utils/pgp.py
@@ -78,6 +78,9 @@ def validate_pgp_signature(
     log_message = result.stderr.replace("\n", " -- ").replace("gpg:                ", "")
     logger.info(f"checked PGP signature, response: {log_message}")
     if result.valid and result.key_status is None:
-        logger.info(f"Found valid PGP signature, pubkey fingerprint {result.pubkey_fingerprint}, fingerprint {result.fingerprint}")
+        logger.info(
+            f"Found valid PGP signature, pubkey fingerprint {result.pubkey_fingerprint}, fingerprint"
+            f" {result.fingerprint}"
+        )
         return new_message, result.pubkey_fingerprint
     return None, None

--- a/irrd/webui/endpoints.py
+++ b/irrd/webui/endpoints.py
@@ -105,9 +105,10 @@ async def rpsl_detail(request: Request, user_mfa_incomplete: bool, session_provi
 
 def optional_csrf_protect(func):
     """
-    The RPSL update endpoint is special re CSRF: it may be called from
-    a browser, with typically a valid CSRF token, or from an API call,
-    without CSRF. Therefore, this decorator tries to validate CSRF,
+    The RPSL update endpoint is special re CSRF: while not entirely supported,
+    users sometimes call this through curl, and miss the CSRF token.
+    It does need CSRF protection, because a logged in user gets additional
+    mntner access. Therefore, this decorator tries to validate CSRF,
     and if not, tells the endpoint, which will then ignore user session
     info and only look at the post data.
     """
@@ -115,8 +116,8 @@ def optional_csrf_protect(func):
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
         try:
-            decorated_func = csrf_protect(func)
-            return await decorated_func(*args, csrf_protected=True, **kwargs)
+            csrf_protected_func = csrf_protect(func)
+            return await csrf_protected_func(*args, csrf_protected=True, **kwargs)
         except CSRFError:
             return await func(*args, csrf_protected=False, **kwargs)
 

--- a/irrd/webui/templates/rpsl_form.html
+++ b/irrd/webui/templates/rpsl_form.html
@@ -28,8 +28,8 @@
                     This form is identical to email submissions, which means you
                     can use the pseudo-attributes <code>delete</code> for deletions
                     or <code>password</code> for password authentication.
-                    PGP is not supported.
-                    See the <a href="TODO">IRRD documentation</a> for more details.
+                    PGP inline signatures are supported.
+                    See the <a href="https://irrd.readthedocs.io/">IRRD documentation</a> for more details.
                 </p>
                 {% if user and user.override %}
                     <p>

--- a/irrd/webui/tests/test_endpoints.py
+++ b/irrd/webui/tests/test_endpoints.py
@@ -190,8 +190,6 @@ class TestRpslUpdateNoInitial(WebRequestTest):
         mock_change_submission_handler,
         tmp_gpg_dir,
     ):
-        # print(test_client.app.user_middleware)
-        # raise Exception()
         session_provider, user = irrd_db_session_with_user
         self._login(test_client, user)
         self._verify_mfa(test_client)


### PR DESCRIPTION
- [x] test w/ PGP
- [x] restore CSRF protection