### PR TITLE
Fixes create for coredis unix socket client

### DIFF
--- a/irrd/storage/event_stream.py
+++ b/irrd/storage/event_stream.py
@@ -18,8 +18,8 @@ REDIS_STREAM_END_IDENTIFIER = "$"
 class AsyncEventStreamRedisClient:
     @classmethod
     async def create(cls):
-        redis_conn = await coredis.Redis(
-            **redis.connection.parse_url(get_setting("redis_url")), protocol_version=2, decode_responses=True
+        redis_conn = await coredis.Redis.from_url(
+            get_setting("redis_url"), protocol_version=2, decode_responses=True
         )
         return cls(redis_conn)
 


### PR DESCRIPTION
Hi,

# BUG
currently event-stream subscription fails since `AsyncEventStreamRedisClient::create` uses `redis.connection.parse_url` which returns `path` and `connection_class` parameters.
Since the parameter for the path should bie `unix_socket_path` it fails and the default TCP connection using localhost ist tried instead which fails after 3 attempts:
```
coredis.exceptions.ConnectionError: [Errno 111] Connection refused
```

# Tested versions
- 4.4.3
- 4.4.4
- 4.5.0b2

# Resolution
This patch uses `coredis.Redis.from_url` instead to use the correct parameters to initialize it.
It is supported at least since coredis 4.0.0 from a quick grep.
A similar function is used in `EventStreamPublisher::__init__` albeit here it's from `redis` module not coredis.

## Note
redis-py has it's own `asyncio` variant. Since using it involves more testing I opted out to use the easier variant using the existing coredis interface instead.