### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,9 @@ html_theme_options = {
     ],
 }
 
+if not os.environ.get("READTHEDOCS"):
+    html_theme_options["font"] = False
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/releases/4.5.0.rst
+++ b/docs/releases/4.5.0.rst
@@ -2,7 +2,7 @@
 Release notes for IRRD 4.5.0
 ============================
 
-IRRD 4.4.0 was released on January 30, 2026. Highlights of new features:
+IRRD 4.5.0 was released on January 30, 2026. Highlights of new features:
 
 * NRTMv4, a new IRR mirroring protocol with much improved
   reliability, security, and error detection over NRTMv3.

--- a/docs/releases/4.5.0.rst
+++ b/docs/releases/4.5.0.rst
@@ -2,6 +2,19 @@
 Release notes for IRRD 4.5.0
 ============================
 
+IRRD 4.4.0 was released on January 30, 2026. Highlights of new features:
+
+* NRTMv4, a new IRR mirroring protocol with much improved
+  reliability, security, and error detection over NRTMv3.
+  NRTMv4 is now the recommended mirroring method for all uses.
+* Support for "dummification" of RPSL objects. This allows removal
+  of certain attributes before they are exported or served through
+  NRTM.
+* An endpoint for Prometheus metrics.
+* A new "RPSL updated" timestamp on sources that allows
+  clearer monitoring.
+* Support for additional object classes.
+
 NRTMv4
 ------
 IRRD 4.5 adds support for NRTMv4_, a new IRR mirroring protocol based
@@ -16,11 +29,11 @@ There are several new settings to enable NRTMv4. You will also need to
 be aware of key management.
 For all details, see the :doc:`mirroring documentation </users/mirroring>`.
 
-IRRD 4.5.0 implements `draft-ietf-grow-nrtm-v4-07`_ specifically.
+IRRD 4.5.0 implements `draft-ietf-grow-nrtm-v4-08`_ specifically.
 Future releases may use newer versions of this draft.
 
 .. _NRTMv4: https://datatracker.ietf.org/doc/draft-ietf-grow-nrtm-v4/
-.. _draft-ietf-grow-nrtm-v4-07: https://datatracker.ietf.org/doc/draft-ietf-grow-nrtm-v4/07/
+.. _draft-ietf-grow-nrtm-v4-08: https://datatracker.ietf.org/doc/draft-ietf-grow-nrtm-v4/08/
 
 New irt and organisation object classes
 ---------------------------------------
@@ -57,7 +70,7 @@ New "RPSL data updated" status timestamp
 Various status overviews of IRRD would show a "last update" per source.
 While there are uses for this, many users checked this to ensure mirroring
 from a remote source was still active. However, that is not what this
-indicates. This timestamp updates for any internal change to database
+indicates: this timestamp updates for any internal change to database
 status, including any exports.
 
 To cover the common use, a new timestamp was added for the last time

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,1 +1,6 @@
-.. include:: ../SECURITY.rst
+===============
+Security policy
+===============
+
+The security policy for IRRD is maintained on GitHub:
+https://github.com/irrdnet/irrd/blob/main/SECURITY.rst


### PR DESCRIPTION
- **Improve readability of 4.5.0 release notes**
- **Link security policy to GitHub main, to prevent serving an outdated version list**
